### PR TITLE
feat: implement drag-and-drop reordering for sub-tags with persistence

### DIFF
--- a/client/components/tag/TagCard.vue
+++ b/client/components/tag/TagCard.vue
@@ -1,11 +1,14 @@
 <script setup lang="ts">
-defineProps<{
+const props = defineProps<{
   group: TagGroupItem
   disabled: boolean
   deleting: boolean
   selected: boolean
   selectedChildIds: string[]
 }>()
+
+const children = computed(() => props.group.children)
+const { orderedItems, draggedIndex, dragOverIndex, onDragStart, onDragOver, onDrop, onDragEnd } = useSubTagOrder(props.group.id, children)
 
 const emit = defineEmits<{
   (e: 'edit', tag: TagDisplayItem): void
@@ -18,53 +21,70 @@ const emit = defineEmits<{
 <template>
   <div
     class="tag-card"
-    :class="{ 'tag-card-personal': !group.isDefault, 'tag-card-selected': selected }"
-    :style="{ '--tag-color': group.color }"
+    :class="{ 'tag-card-personal': !props.group.isDefault, 'tag-card-selected': selected }"
+    :style="{ '--tag-color': props.group.color }"
   >
-    <div class="tag-color-band" :style="{ backgroundColor: group.color }" />
+    <div class="tag-color-band" :style="{ backgroundColor: props.group.color }" />
 
     <div class="tag-content">
       <div class="tag-info">
         <div class="tag-header">
           <Checkbox
-            v-if="!group.isDefault"
+            v-if="!props.group.isDefault"
             :binary="true"
             :model-value="selected"
             class="tag-select-checkbox"
             aria-label="Sélectionner ce tag"
-            @update:model-value="() => emit('toggle-select', group)"
+            @update:model-value="() => emit('toggle-select', props.group)"
           />
           <div class="tag-label-wrapper">
             <h3 class="tag-label">
-              {{ group.label }}
+              {{ props.group.label }}
             </h3>
             <Tag
-              :value="group.isDefault ? 'Par défaut' : 'Personnel'"
-              :severity="group.isDefault ? 'info' : 'success'"
+              :value="props.group.isDefault ? 'Par défaut' : 'Personnel'"
+              :severity="props.group.isDefault ? 'info' : 'success'"
               class="tag-badge"
             />
           </div>
         </div>
 
         <div class="color-preview">
-          <div class="color-circle" :style="{ backgroundColor: group.color }" />
-          <span class="color-label">{{ group.color }}</span>
+          <div class="color-circle" :style="{ backgroundColor: props.group.color }" />
+          <span class="color-label">{{ props.group.color }}</span>
         </div>
       </div>
 
-      <div v-if="group.children.length > 0" class="sub-tags-section">
+      <div v-if="props.group.children.length > 0" class="sub-tags-section">
         <p class="sub-tags-header">
           <i class="pi pi-sitemap" />
-          Sous-tags ({{ group.children.length }})
+          Sous-tags ({{ props.group.children.length }})
         </p>
         <div class="sub-tags-list">
           <div
-            v-for="child in group.children"
+            v-for="(child, index) in orderedItems"
             :key="child.id"
             class="sub-tag-chip"
-            :class="{ 'sub-tag-chip-selected': selectedChildIds.includes(child.id) }"
+            :class="{
+              'sub-tag-chip-selected': selectedChildIds.includes(child.id),
+              'is-dragging': draggedIndex === index,
+              'drag-over': dragOverIndex === index && draggedIndex !== index,
+            }"
             :style="{ borderLeftColor: child.color }"
+            :draggable="props.group.children.length > 1"
+            @dragstart="onDragStart($event, index)"
+            @dragover="onDragOver($event, index)"
+            @drop="onDrop($event, index)"
+            @dragend="onDragEnd"
           >
+            <button
+              v-if="props.group.children.length > 1"
+              v-tooltip.top="'Réorganiser'"
+              class="sub-tag-drag-handle"
+              @click.stop
+            >
+              <i class="pi pi-bars" />
+            </button>
             <Checkbox
               v-if="!child.isDefault"
               :binary="true"
@@ -103,7 +123,7 @@ const emit = defineEmits<{
         </div>
       </div>
 
-      <div v-if="!group.isDefault" class="tag-actions">
+      <div v-if="!props.group.isDefault" class="tag-actions">
         <Button
           v-tooltip.top="'Modifier'"
           icon="pi pi-pencil"
@@ -112,7 +132,7 @@ const emit = defineEmits<{
           severity="secondary"
           :disabled="disabled"
           aria-label="Modifier"
-          @click="emit('edit', group)"
+          @click="emit('edit', props.group)"
         />
         <Button
           v-tooltip.top="'Supprimer'"
@@ -123,7 +143,7 @@ const emit = defineEmits<{
           :loading="deleting"
           :disabled="disabled"
           aria-label="Supprimer"
-          @click="emit('delete', group)"
+          @click="emit('delete', props.group)"
         />
       </div>
     </div>
@@ -287,7 +307,7 @@ const emit = defineEmits<{
   border-radius: 6px;
   border-left: 3px solid;
   background: var(--bg-tertiary);
-  transition: background 0.2s ease;
+  transition: background 0.2s ease, opacity 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
 
   &:hover {
     background: var(--bg-hover, var(--bg-tertiary));
@@ -295,6 +315,55 @@ const emit = defineEmits<{
     .sub-tag-actions {
       opacity: 1;
     }
+
+    .sub-tag-drag-handle {
+      opacity: 1;
+    }
+  }
+
+  &.is-dragging {
+    opacity: 0.4;
+    transform: scale(0.98);
+    box-shadow: none;
+  }
+
+  &.drag-over {
+    box-shadow: 0 -2px 0 0 var(--p-primary-color, #6366f1);
+    background: color-mix(in srgb, var(--p-primary-color, #6366f1) 6%, var(--bg-tertiary));
+  }
+}
+
+.sub-tag-drag-handle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border: none;
+  background: transparent;
+  color: var(--text-tertiary);
+  cursor: grab;
+  border-radius: 4px;
+  transition: all 0.2s ease;
+  padding: 0;
+  opacity: 0;
+  flex-shrink: 0;
+
+  @media (max-width: 768px) {
+    opacity: 1;
+  }
+
+  &:active {
+    cursor: grabbing;
+  }
+
+  &:hover {
+    color: var(--primary, var(--p-primary-color));
+    background: color-mix(in srgb, var(--p-primary-color, #6366f1) 10%, transparent);
+  }
+
+  i {
+    font-size: 0.75rem;
   }
 }
 

--- a/client/composables/useSubTagOrder.ts
+++ b/client/composables/useSubTagOrder.ts
@@ -1,0 +1,58 @@
+import type { Ref } from 'vue'
+
+const SUB_TAG_ORDER_KEY_PREFIX = 'jmanager-subtag-order'
+
+/**
+ * Provides drag-and-drop reordering for a list of sub-tags scoped to a parent tag,
+ * with localStorage persistence keyed by parentId.
+ */
+export function useSubTagOrder(parentId: string, items: Ref<TagDisplayItem[]>) {
+  const savedOrder = useLocalStorage<string[]>(`${SUB_TAG_ORDER_KEY_PREFIX}-${parentId}`, [])
+  const draggedIndex = ref<number | null>(null)
+  const dragOverIndex = ref<number | null>(null)
+
+  const orderedItems = computed(() => {
+    if (!savedOrder.value.length) return items.value
+    const orderMap = new Map(savedOrder.value.map((id, i) => [id, i]))
+    return [...items.value].sort((a, b) => {
+      const ai = orderMap.has(a.id) ? orderMap.get(a.id)! : Infinity
+      const bi = orderMap.has(b.id) ? orderMap.get(b.id)! : Infinity
+      return ai - bi
+    })
+  })
+
+  function onDragStart(event: DragEvent, index: number) {
+    draggedIndex.value = index
+    if (event.dataTransfer) event.dataTransfer.effectAllowed = 'move'
+  }
+
+  function onDragOver(event: DragEvent, index: number) {
+    event.preventDefault()
+    if (event.dataTransfer) event.dataTransfer.dropEffect = 'move'
+    dragOverIndex.value = index
+  }
+
+  function onDrop(event: DragEvent, targetIndex: number) {
+    event.preventDefault()
+    if (draggedIndex.value === null || draggedIndex.value === targetIndex) {
+      draggedIndex.value = null
+      dragOverIndex.value = null
+      return
+    }
+    const reordered = [...orderedItems.value]
+    const [moved] = reordered.splice(draggedIndex.value, 1)
+    reordered.splice(targetIndex, 0, moved)
+    savedOrder.value = reordered.map(t => t.id)
+    draggedIndex.value = null
+    dragOverIndex.value = null
+  }
+
+  function onDragEnd() {
+    draggedIndex.value = null
+    dragOverIndex.value = null
+  }
+
+  return { orderedItems, draggedIndex, dragOverIndex, onDragStart, onDragOver, onDrop, onDragEnd }
+}
+
+export default useSubTagOrder

--- a/client/tests/setup.ts
+++ b/client/tests/setup.ts
@@ -37,6 +37,15 @@ vi.stubGlobal('useBookletOrder', (items: any) => ({
   onDrop: vi.fn(),
   onDragEnd: vi.fn(),
 }))
+vi.stubGlobal('useSubTagOrder', (_parentId: string, items: any) => ({
+  orderedItems: computed(() => items.value),
+  draggedIndex: ref(null),
+  dragOverIndex: ref(null),
+  onDragStart: vi.fn(),
+  onDragOver: vi.fn(),
+  onDrop: vi.fn(),
+  onDragEnd: vi.fn(),
+}))
 
 config.global.stubs = {
   Transition: false,

--- a/client/tests/unit/useSubTagOrder.spec.ts
+++ b/client/tests/unit/useSubTagOrder.spec.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+import useSubTagOrder from '../../composables/useSubTagOrder'
+
+interface Item { id: string }
+
+function mockDragEvent(overrides: Record<string, any> = {}): DragEvent {
+  return { preventDefault: vi.fn(), dataTransfer: { effectAllowed: '', dropEffect: '' }, ...overrides } as any
+}
+
+describe('composables/useSubTagOrder', () => {
+  it('returns items in original order when no saved order exists', () => {
+    const items = ref<Item[]>([{ id: 'a' }, { id: 'b' }, { id: 'c' }])
+    const { orderedItems } = useSubTagOrder('parent-1', items as any)
+
+    expect(orderedItems.value.map(i => i.id)).toEqual(['a', 'b', 'c'])
+  })
+
+  it('onDragStart sets draggedIndex', () => {
+    const items = ref<Item[]>([{ id: 'a' }, { id: 'b' }])
+    const { draggedIndex, onDragStart } = useSubTagOrder('parent-1', items as any)
+
+    onDragStart(mockDragEvent(), 0)
+
+    expect(draggedIndex.value).toBe(0)
+  })
+
+  it('onDragOver updates dragOverIndex', () => {
+    const items = ref<Item[]>([{ id: 'a' }, { id: 'b' }])
+    const { dragOverIndex, onDragOver } = useSubTagOrder('parent-1', items as any)
+
+    onDragOver(mockDragEvent(), 1)
+
+    expect(dragOverIndex.value).toBe(1)
+  })
+
+  it('onDragEnd resets drag state', () => {
+    const items = ref<Item[]>([{ id: 'a' }, { id: 'b' }])
+    const { draggedIndex, dragOverIndex, onDragStart, onDragEnd } = useSubTagOrder('parent-1', items as any)
+
+    onDragStart(mockDragEvent(), 0)
+    expect(draggedIndex.value).toBe(0)
+
+    onDragEnd()
+
+    expect(draggedIndex.value).toBeNull()
+    expect(dragOverIndex.value).toBeNull()
+  })
+
+  it('onDrop reorders items and persists new order via savedOrder', () => {
+    const items = ref<Item[]>([{ id: 'a' }, { id: 'b' }, { id: 'c' }])
+    const { orderedItems, onDragStart, onDrop } = useSubTagOrder('parent-1', items as any)
+
+    onDragStart(mockDragEvent(), 0)
+    onDrop(mockDragEvent(), 2)
+
+    expect(orderedItems.value.map(i => i.id)).toEqual(['b', 'c', 'a'])
+  })
+
+  it('onDrop does nothing when source and target index are identical', () => {
+    const items = ref<Item[]>([{ id: 'a' }, { id: 'b' }, { id: 'c' }])
+    const { orderedItems, draggedIndex, onDragStart, onDrop } = useSubTagOrder('parent-1', items as any)
+
+    onDragStart(mockDragEvent(), 1)
+    onDrop(mockDragEvent(), 1)
+
+    expect(orderedItems.value.map(i => i.id)).toEqual(['a', 'b', 'c'])
+    expect(draggedIndex.value).toBeNull()
+  })
+
+  it('onDrop resets drag state after reorder', () => {
+    const items = ref<Item[]>([{ id: 'a' }, { id: 'b' }])
+    const { draggedIndex, dragOverIndex, onDragStart, onDragOver, onDrop } = useSubTagOrder('parent-1', items as any)
+
+    onDragStart(mockDragEvent(), 0)
+    onDragOver(mockDragEvent(), 1)
+    onDrop(mockDragEvent(), 1)
+
+    expect(draggedIndex.value).toBeNull()
+    expect(dragOverIndex.value).toBeNull()
+  })
+
+  it('scopes storage independently per parentId', () => {
+    const items1 = ref<Item[]>([{ id: 'a' }, { id: 'b' }])
+    const items2 = ref<Item[]>([{ id: 'x' }, { id: 'y' }])
+
+    const order1 = useSubTagOrder('parent-1', items1 as any)
+    const order2 = useSubTagOrder('parent-2', items2 as any)
+
+    order1.onDragStart(mockDragEvent(), 0)
+    order1.onDrop(mockDragEvent(), 1)
+
+    expect(order1.orderedItems.value.map(i => i.id)).toEqual(['b', 'a'])
+    expect(order2.orderedItems.value.map(i => i.id)).toEqual(['x', 'y'])
+  })
+})


### PR DESCRIPTION
## 🐛 Bug Fix

> **Branch:** `fix/change-order-of-subtags` → `master`
> **Modules:** `client`

---

## 📝 Description

_Auto-generated — please complete this section._

## ✅ Changes

- feat: implement drag-and-drop reordering for sub-tags with persistence

## 📁 Modified Files

**`client`** — 4 file(s)
  - `client/components/tag/TagCard.vue`
  - `client/composables/useSubTagOrder.ts`
  - `client/tests/setup.ts`
  - `client/tests/unit/useSubTagOrder.spec.ts`

## 🧪 Testing

- [ ] Unit / domain tests pass
- [ ] Integration tests pass
- [ ] Frontend tests pass

## 📋 Checklist

- [ ] Code follows project conventions
- [ ] Changelog updated
- [ ] No debug code left