### PR TITLE
fix(domain): seed daily cumulative balance from actual booklet balanc…

### DIFF
--- a/domain/src/main/kotlin/fr/sacane/jmanager/domain/models/Booklet.kt
+++ b/domain/src/main/kotlin/fr/sacane/jmanager/domain/models/Booklet.kt
@@ -2,6 +2,7 @@ package fr.sacane.jmanager.domain.models
 
 import fr.sacane.jmanager.domain.models.transaction.Transaction
 import fr.sacane.jmanager.domain.models.transaction.regular.RegularTransaction
+import java.time.LocalDate
 import java.time.Month
 import java.util.UUID
 
@@ -94,6 +95,15 @@ class Booklet(
             monthlyPeriodEndDay: $monthlyPeriodEndDay
             owner: ${owner?.id}
         """.trimIndent()
+    }
+
+    fun balanceAt(date: LocalDate): Amount {
+        return transactions
+            .filter { !it.isPreview && it.date.isBefore(date) }
+            .fold(initialSold) { balance, transaction ->
+                if (transaction.isIncome) balance + transaction.amount
+                else balance - transaction.amount
+            }
     }
 
     fun addTransaction(transaction: Transaction) {

--- a/domain/src/main/kotlin/fr/sacane/jmanager/domain/port/input/stats/GetDailyTrendStatsUseCase.kt
+++ b/domain/src/main/kotlin/fr/sacane/jmanager/domain/port/input/stats/GetDailyTrendStatsUseCase.kt
@@ -3,6 +3,8 @@ package fr.sacane.jmanager.domain.port.input.stats
 import fr.sacane.jmanager.domain.hexadoc.DomainService
 import fr.sacane.jmanager.domain.hexadoc.Port
 import fr.sacane.jmanager.domain.hexadoc.Side
+import fr.sacane.jmanager.domain.models.Amount
+import fr.sacane.jmanager.domain.models.Booklet
 import fr.sacane.jmanager.domain.models.DailyTrendStatsOutput
 import fr.sacane.jmanager.domain.models.UserId
 import fr.sacane.jmanager.domain.port.output.repository.BookletRepository
@@ -12,9 +14,13 @@ import fr.sacane.jmanager.domain.port.input.QueryHandler
 import fr.sacane.jmanager.domain.utils.Result
 import fr.sacane.jmanager.domain.utils.ResultState
 import fr.sacane.jmanager.domain.utils.success
+import java.math.BigDecimal
 import java.time.LocalDate
 import java.util.UUID
 import java.util.logging.Logger
+
+private fun List<Booklet>.aggregateBalanceAt(date: LocalDate): Amount =
+    fold(Amount(BigDecimal.ZERO)) { acc, booklet -> acc + booklet.balanceAt(date) }
 
 data class GetDailyTrendStatsQuery(
     val userId: UserId,
@@ -51,10 +57,12 @@ class GetDailyTrendStatsService(
         }
 
         return withScopedBooklets(bookletRepository, userId, query.bookletId) { scopedBooklets ->
+            val startingBalance = scopedBooklets.aggregateBalanceAt(query.startDate)
             val dailyTrends = dailyTrendCalculator.calculateDailyTrend(
                 booklets = scopedBooklets,
                 startDate = query.startDate,
-                endDate = query.endDate
+                endDate = query.endDate,
+                startingBalance = startingBalance
             )
 
             LOGGER.info("Daily trend stats calculated: ${dailyTrends.size} days processed")

--- a/domain/src/main/kotlin/fr/sacane/jmanager/domain/usecase/DailyTrendCalculator.kt
+++ b/domain/src/main/kotlin/fr/sacane/jmanager/domain/usecase/DailyTrendCalculator.kt
@@ -16,12 +16,14 @@ interface DailyTrendCalculator {
      * @param booklets the list of booklets from which transactions are aggregated
      * @param startDate the first day of the range (inclusive)
      * @param endDate the last day of the range (inclusive)
+     * @param startingBalance the actual account balance at the start of the period; seeds the cumulative accumulator
      * @return a list of DailyTrend, one entry per day in the range, ordered chronologically
      */
     fun calculateDailyTrend(
         booklets: List<Booklet>,
         startDate: LocalDate,
-        endDate: LocalDate
+        endDate: LocalDate,
+        startingBalance: Amount = Amount(BigDecimal.ZERO)
     ): List<DailyTrend>
 }
 
@@ -30,10 +32,11 @@ class DailyTrendCalculatorImpl : DailyTrendCalculator {
     override fun calculateDailyTrend(
         booklets: List<Booklet>,
         startDate: LocalDate,
-        endDate: LocalDate
+        endDate: LocalDate,
+        startingBalance: Amount
     ): List<DailyTrend> {
         val days = generateDayRange(startDate, endDate)
-        var cumulativeBalance = BigDecimal.ZERO
+        var cumulativeBalance = startingBalance.value
 
         return days.map { day ->
             val dayTransactions = booklets.flatMap { booklet ->

--- a/domain/src/test/kotlin/fr/sacane/jmanager/domain/models/BookletTest.kt
+++ b/domain/src/test/kotlin/fr/sacane/jmanager/domain/models/BookletTest.kt
@@ -243,4 +243,54 @@ class BookletTest {
 
         assertTrue(booklet.regularTransactions.isEmpty())
     }
+
+    @Test
+    fun `balanceAt returns initialSold when no transactions exist before the date`() {
+        val booklet = Booklet(1000.toAmount(), "Test")
+
+        val balance = booklet.balanceAt(LocalDate.of(2025, 1, 1))
+
+        assertEquals(1000.toAmount(), balance)
+    }
+
+    @Test
+    fun `balanceAt adds income transactions before the date to initialSold`() {
+        val booklet = Booklet(1000.toAmount(), "Test")
+        booklet.addTransaction(Transaction(UUID.randomUUID(), "Income", LocalDate.of(2024, 12, 31), 500.toAmount(), isIncome = true))
+
+        val balance = booklet.balanceAt(LocalDate.of(2025, 1, 1))
+
+        assertEquals(1500.toAmount(), balance)
+    }
+
+    @Test
+    fun `balanceAt subtracts expense transactions before the date from initialSold`() {
+        val booklet = Booklet(1000.toAmount(), "Test")
+        booklet.addTransaction(Transaction(UUID.randomUUID(), "Expense", LocalDate.of(2024, 12, 31), 200.toAmount(), isIncome = false))
+
+        val balance = booklet.balanceAt(LocalDate.of(2025, 1, 1))
+
+        assertEquals(800.toAmount(), balance)
+    }
+
+    @Test
+    fun `balanceAt excludes transactions on or after the date`() {
+        val booklet = Booklet(1000.toAmount(), "Test")
+        booklet.addTransaction(Transaction(UUID.randomUUID(), "Same day", LocalDate.of(2025, 1, 1), 500.toAmount(), isIncome = true))
+        booklet.addTransaction(Transaction(UUID.randomUUID(), "After", LocalDate.of(2025, 1, 5), 500.toAmount(), isIncome = true))
+
+        val balance = booklet.balanceAt(LocalDate.of(2025, 1, 1))
+
+        assertEquals(1000.toAmount(), balance)
+    }
+
+    @Test
+    fun `balanceAt excludes preview transactions before the date`() {
+        val booklet = Booklet(1000.toAmount(), "Test")
+        booklet.addTransaction(Transaction(UUID.randomUUID(), "Preview", LocalDate.of(2024, 12, 31), 500.toAmount(), isIncome = true, isPreview = true))
+
+        val balance = booklet.balanceAt(LocalDate.of(2025, 1, 1))
+
+        assertEquals(1000.toAmount(), balance)
+    }
 }

--- a/domain/src/test/kotlin/fr/sacane/jmanager/domain/port/StatsFeatureTest.kt
+++ b/domain/src/test/kotlin/fr/sacane/jmanager/domain/port/StatsFeatureTest.kt
@@ -572,6 +572,50 @@ class StatsFeatureTest {
         }
 
         @Test
+        fun `cumulative balance is seeded from booklet balance before period start`() {
+            val ctx = scenario.withUser().withBooklet()
+            transactionState.initWith(IdBookletByTransaction(IdUserBooklet(ctx.userId, ctx.booklet.id!!), mutableListOf(
+                tx("Pre-period income", BigDecimal("500"), true, LocalDate.of(2024, 12, 31)),
+                tx("In-period expense", BigDecimal("200"), false, LocalDate.of(2025, 1, 5))
+            )))
+
+            // booklet initialSold = 0, pre-period income = +500 => startingBalance = 500
+            // day 1: no in-period tx => cumulative = 500
+            // day 5: expense 200 => cumulative = 300
+            getDailyTrendStatsUseCase.handle(GetDailyTrendStatsQuery(
+                userId = ctx.userId, startDate = LocalDate.of(2025, 1, 1), endDate = LocalDate.of(2025, 1, 31), bookletId = ctx.booklet.id
+            )).assertTrue {
+                val day1 = this.dailyTrends.find { it.date == LocalDate.of(2025, 1, 1) }
+                val day5 = this.dailyTrends.find { it.date == LocalDate.of(2025, 1, 5) }
+                day1 != null && day1.cumulativeBalance.value.compareTo(BigDecimal("500")) == 0 &&
+                    day5 != null && day5.cumulativeBalance.value.compareTo(BigDecimal("300")) == 0
+            }
+        }
+
+        @Test
+        fun `cumulative balance aggregates starting balances of all booklets`() {
+            val ctx = scenario.withUser().withBooklet()
+            transactionState.initWith(IdBookletByTransaction(IdUserBooklet(ctx.userId, ctx.booklet.id!!), mutableListOf(
+                tx("B1 pre-period", BigDecimal("300"), true, LocalDate.of(2024, 12, 31))
+            )))
+
+            val booklet2 = Booklet(Amount(BigDecimal("200")), "booklet2", owner = ctx.user, id = UUID.randomUUID())
+            bookletState.init(listOf(BookletsByOwner(listOf(booklet2), ctx.userId)))
+            transactionState.init(listOf(IdBookletByTransaction(IdUserBooklet(ctx.userId, booklet2.id!!), mutableListOf(
+                tx("B2 pre-period", BigDecimal("100"), true, LocalDate.of(2024, 12, 31))
+            ))))
+
+            // booklet1 initialSold=0 + 300 = 300, booklet2 initialSold=200 + 100 = 300
+            // combined startingBalance = 600
+            getDailyTrendStatsUseCase.handle(GetDailyTrendStatsQuery(
+                userId = ctx.userId, startDate = LocalDate.of(2025, 1, 1), endDate = LocalDate.of(2025, 1, 31), bookletId = null
+            )).assertTrue {
+                val day1 = this.dailyTrends.find { it.date == LocalDate.of(2025, 1, 1) }
+                day1 != null && day1.cumulativeBalance.value.compareTo(BigDecimal("600")) == 0
+            }
+        }
+
+        @Test
         fun `Should scope daily trends to selected booklet`() {
             val ctx = scenario.withUser().withBooklet()
             transactionState.initWith(IdBookletByTransaction(IdUserBooklet(ctx.userId, ctx.booklet.id!!), mutableListOf(

--- a/domain/src/test/kotlin/fr/sacane/jmanager/domain/usecase/DailyTrendCalculatorTest.kt
+++ b/domain/src/test/kotlin/fr/sacane/jmanager/domain/usecase/DailyTrendCalculatorTest.kt
@@ -245,6 +245,55 @@ class DailyTrendCalculatorTest {
     }
 
     @Test
+    fun `cumulative balance is seeded from a non-zero starting balance`() {
+        val booklet = Booklet(0.toAmount(), "Booklet")
+        booklet.addTransaction(
+            Transaction(UUID.randomUUID(), "Income", LocalDate.of(2025, 1, 5), 500.toAmount(), isIncome = true)
+        )
+
+        val trends = calculator.calculateDailyTrend(
+            booklets = listOf(booklet),
+            startDate = LocalDate.of(2025, 1, 1),
+            endDate = LocalDate.of(2025, 1, 31),
+            startingBalance = 2000.toAmount()
+        )
+
+        val day1 = trends.find { it.date == LocalDate.of(2025, 1, 1) }!!
+        assertEquals(BigDecimal("2000.00"), day1.cumulativeBalance.value)
+
+        val day5 = trends.find { it.date == LocalDate.of(2025, 1, 5) }!!
+        assertEquals(BigDecimal("2500.00"), day5.cumulativeBalance.value)
+    }
+
+    @Test
+    fun `starting balance shifts all cumulative values uniformly`() {
+        val booklet = Booklet(0.toAmount(), "Booklet")
+        booklet.addTransaction(
+            Transaction(UUID.randomUUID(), "Expense", LocalDate.of(2025, 1, 10), 300.toAmount(), isIncome = false)
+        )
+
+        val trendsWithSeed = calculator.calculateDailyTrend(
+            booklets = listOf(booklet),
+            startDate = LocalDate.of(2025, 1, 1),
+            endDate = LocalDate.of(2025, 1, 31),
+            startingBalance = 1000.toAmount()
+        )
+        val trendsFromZero = calculator.calculateDailyTrend(
+            booklets = listOf(booklet),
+            startDate = LocalDate.of(2025, 1, 1),
+            endDate = LocalDate.of(2025, 1, 31),
+            startingBalance = 0.toAmount()
+        )
+
+        trendsWithSeed.zip(trendsFromZero).forEach { (seeded, zeroBased) ->
+            assertEquals(
+                BigDecimal("1000.00").add(zeroBased.cumulativeBalance.value),
+                seeded.cumulativeBalance.value
+            )
+        }
+    }
+
+    @Test
     fun `should exclude transactions outside the date range`() {
         val booklet = Booklet(1000.toAmount(), "Booklet")
         booklet.addTransaction(


### PR DESCRIPTION
## 🔀 Change

> **Branch:** `ui/global-transaction-filter` → `master`
> **Modules:** `domain`

---

## 📝 Description

_Auto-generated — please complete this section._

## ✅ Changes

- fix(domain): seed daily cumulative balance from actual booklet balance at period start

## 📁 Modified Files

**`domain`** — 6 file(s)
  - `domain/src/main/kotlin/fr/sacane/jmanager/domain/models/Booklet.kt`
  - `domain/src/main/kotlin/fr/sacane/jmanager/domain/port/input/stats/GetDailyTrendStatsUseCase.kt`
  - `domain/src/main/kotlin/fr/sacane/jmanager/domain/usecase/DailyTrendCalculator.kt`
  - `domain/src/test/kotlin/fr/sacane/jmanager/domain/models/BookletTest.kt`
  - `domain/src/test/kotlin/fr/sacane/jmanager/domain/port/StatsFeatureTest.kt`
  - `domain/src/test/kotlin/fr/sacane/jmanager/domain/usecase/DailyTrendCalculatorTest.kt`

## 🧪 Testing

- [ ] Unit / domain tests pass
- [ ] Integration tests pass
- [ ] Frontend tests pass

## 📋 Checklist

- [ ] Code follows project conventions
- [ ] Changelog updated
- [ ] No debug code left