### PR TITLE
feat(observability): structured logging strategy

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,33 @@
 
 ## [En cours]
 
+## 2026-05-25
+
+- **Observability: VPS-tuned Logback configuration (`logback-spring.xml`)**
+  - Created `application/src/main/resources/logback-spring.xml` with full Spring profile separation (`local/test` and `prod`).
+  - `prod` profile: two `RollingFileAppender` instances — `app.log` (INFO+, 100 MB rotation, 30 days, 1.5 GB cap) and `error.log` (ERROR only, 50 MB rotation, 90 days, 300 MB cap); both wrapped in `AsyncAppender` (`queueSize=1024`, `discardingThreshold=0`, `neverBlock=false`) to decouple disk I/O from HTTP threads.
+  - `local/test` profile: colour console appender with highlighted levels, SQL visibility (`org.hibernate.SQL=DEBUG`), and Spring Web request mapping logs.
+  - Noisy third-party libs (`hibernate`, `spring`, `hikari`, `tomcat`) silenced to WARN in production.
+
+- **Observability: Bus-level dispatch logging + JUL → SLF4J migration**
+  - Created `LoggingCommandBus` and `LoggingQueryBus` as `@Primary` `@Component` decorators wrapping `SpringCommandBus` / `SpringQueryBus`.
+  - Each dispatch emits one structured INFO line: `COMMAND | <name> | <ResultState> | <ms> ms` / `QUERY  | ...`.
+  - Fixed `CommandBus` and `QueryBus` Spring components: migrated from `java.util.logging.Logger` (JUL) to SLF4J; renamed `LOGGER` → `log`; replaced string concatenation with `{}` parameterised syntax.
+  - Added `docs/technical/bus-logging/2026-05-25-command-query-dispatch-logging.md` documenting the Decorator vs AOP trade-off.
+
+- **Observability: Domain logging pass**
+  - Removed PII-leaking logs: `LoginUseCase` no longer logs user ID or username; `BookTransactionUseCase` no longer prints full object `toString()`.
+  - Removed useless / expensive logs: removed echoing of input parameters that duplicate what the bus already traces; replaced costly object interpolation with targeted field references.
+  - Added pertinent logs where missing: `RegisterUserUseCase` now logs subscription plan on success; `DeleteBookletByIdUseCase` logs booklet ID on delete; `DeleteTagUseCase` logs force-delete with tag-in-use count.
+  - Added SLF4J dependency to `domain/build.gradle.kts` (`slf4j-api:2.0.16`) — domain previously had no logging façade.
+  - Completed JUL → SLF4J migration across all domain use cases that still used `java.util.logging`.
+
+- **Observability: MDC context propagation**
+  - Created `MdcContextProvider` interface and `MdcKeys` constants object in `domain/port/input/MdcContext.kt` — pure domain, zero SLF4J import.
+  - `LoggingCommandBus` and `LoggingQueryBus` extract the MDC context from the command/query (when it implements `MdcContextProvider`), call `MDC.put()` before dispatch, and guarantee `MDC.remove()` in a `finally` block to prevent cross-request context leaks.
+  - 13 commands and queries now implement `MdcContextProvider`: `LoadTransactionsForBookletForAMonthQuery`, `FindBookletByIdQuery`, `LoadBalancesForBookletForAMonthQuery`, `DeleteBookletByIdCommand`, `EditBookletCommand`, `RegenerateDeletedPrevisionalTransactionsCommand`, `DeleteTransactionsByIdsCommand`, `EditTransactionCommand`, `ConfirmVirtualTransactionCommand`, `ConfirmPreviewTransactionCommand`, `ExcludeVirtualTransactionCommand`, `FindTransactionByIdQuery`, `ImportTransactionsFromCsvCommand`.
+  - Logback patterns updated in both profiles to conditionally render `[booklet=<id>]` and `[tx=<id>]` only when the MDC key is populated, using `%replace` with empty-value suppression.
+
 ## 2026-05-23
 
 - **Feature: Subscription Plan model (`BETA_TESTER`, `FREE`, `PREMIUM`)**

--- a/application/src/main/kotlin/fr/sacane/jmanager/application/bus/CommandBus.kt
+++ b/application/src/main/kotlin/fr/sacane/jmanager/application/bus/CommandBus.kt
@@ -3,8 +3,8 @@ package fr.sacane.jmanager.application.bus
 import fr.sacane.jmanager.domain.port.input.Command
 import fr.sacane.jmanager.domain.port.input.CommandHandler
 import fr.sacane.jmanager.domain.utils.Result
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
-import java.util.logging.Logger
 
 /**
  * Dispatches a [Command] to the appropriate [CommandHandler].
@@ -17,12 +17,12 @@ interface CommandBus {
 class SpringCommandBus(handlers: List<CommandHandler<*, *>>) : CommandBus {
 
     companion object {
-        private val LOGGER = Logger.getLogger(SpringCommandBus::class.java.name)
+        private val log = LoggerFactory.getLogger(SpringCommandBus::class.java)
     }
 
     private val handlerMap: Map<Class<*>, CommandHandler<*, *>> =
         handlers.associateBy { it.commandClass.java as Class<*> }
-            .also { LOGGER.info("CommandBus initialized with ${it.size} handler(s): ${it.keys.map { k -> k.simpleName }}") }
+            .also { log.info("CommandBus initialized with {} handler(s): {}", it.size, it.keys.map { k -> k.simpleName }) }
 
     @Suppress("UNCHECKED_CAST")
     override fun <R> dispatch(command: Command<R>): Result<R> {

--- a/application/src/main/kotlin/fr/sacane/jmanager/application/bus/LoggingCommandBus.kt
+++ b/application/src/main/kotlin/fr/sacane/jmanager/application/bus/LoggingCommandBus.kt
@@ -1,0 +1,36 @@
+package fr.sacane.jmanager.application.bus
+
+import fr.sacane.jmanager.domain.port.input.Command
+import fr.sacane.jmanager.domain.utils.Result
+import org.slf4j.LoggerFactory
+import org.springframework.context.annotation.Primary
+import org.springframework.stereotype.Component
+
+/**
+ * Decorator around [SpringCommandBus] that logs every command dispatch.
+ *
+ * Emits one INFO line per dispatch:
+ * ```
+ * COMMAND | SaveBookletCommand              | OK               |  12 ms
+ * COMMAND | DeleteBookletByIdCommand        | BOOKLET_NOT_FOUND |   3 ms
+ * ```
+ *
+ * No payload is logged — command fields may contain user data.
+ */
+@Primary
+@Component
+class LoggingCommandBus(
+    private val delegate: SpringCommandBus
+) : CommandBus {
+
+    private val log = LoggerFactory.getLogger(LoggingCommandBus::class.java)
+
+    override fun <R> dispatch(command: Command<R>): Result<R> {
+        val name = command::class.simpleName ?: "UnknownCommand"
+        val start = System.nanoTime()
+        val result = delegate.dispatch(command)
+        val ms = (System.nanoTime() - start) / 1_000_000
+        log.info("COMMAND | {:<50} | {:<30} | {} ms", name, result.status.name, ms)
+        return result
+    }
+}

--- a/application/src/main/kotlin/fr/sacane/jmanager/application/bus/LoggingCommandBus.kt
+++ b/application/src/main/kotlin/fr/sacane/jmanager/application/bus/LoggingCommandBus.kt
@@ -1,20 +1,25 @@
 package fr.sacane.jmanager.application.bus
 
 import fr.sacane.jmanager.domain.port.input.Command
+import fr.sacane.jmanager.domain.port.input.MdcContextProvider
 import fr.sacane.jmanager.domain.utils.Result
 import org.slf4j.LoggerFactory
+import org.slf4j.MDC
 import org.springframework.context.annotation.Primary
 import org.springframework.stereotype.Component
 
 /**
- * Decorator around [SpringCommandBus] that logs every command dispatch.
+ * Decorator around [SpringCommandBus] that:
+ * 1. Injects domain context (bookletId, transactionId) into the SLF4J MDC for the duration
+ *    of the dispatch when the command implements [MdcContextProvider].
+ * 2. Emits one INFO line per dispatch with the command name, result state, and execution time.
  *
- * Emits one INFO line per dispatch:
  * ```
  * COMMAND | SaveBookletCommand              | OK               |  12 ms
  * COMMAND | DeleteBookletByIdCommand        | BOOKLET_NOT_FOUND |   3 ms
  * ```
  *
+ * MDC is cleared in a `finally` block — no context leaks across requests.
  * No payload is logged — command fields may contain user data.
  */
 @Primary
@@ -27,10 +32,23 @@ class LoggingCommandBus(
 
     override fun <R> dispatch(command: Command<R>): Result<R> {
         val name = command::class.simpleName ?: "UnknownCommand"
+        val mdcKeys = putMdcContext(command)
         val start = System.nanoTime()
-        val result = delegate.dispatch(command)
-        val ms = (System.nanoTime() - start) / 1_000_000
-        log.info("COMMAND | {:<50} | {:<30} | {} ms", name, result.status.name, ms)
-        return result
+        return try {
+            val result = delegate.dispatch(command)
+            val ms = (System.nanoTime() - start) / 1_000_000
+            log.info("COMMAND | {:<50} | {:<30} | {} ms", name, result.status.name, ms)
+            result
+        } finally {
+            mdcKeys.forEach { MDC.remove(it) }
+        }
+    }
+
+    private fun putMdcContext(command: Command<*>): Set<String> {
+        if (command !is MdcContextProvider) return emptySet()
+        return command.mdcContext()
+            .filterValues { it.isNotBlank() }
+            .also { ctx -> ctx.forEach { (k, v) -> MDC.put(k, v) } }
+            .keys
     }
 }

--- a/application/src/main/kotlin/fr/sacane/jmanager/application/bus/LoggingQueryBus.kt
+++ b/application/src/main/kotlin/fr/sacane/jmanager/application/bus/LoggingQueryBus.kt
@@ -1,0 +1,36 @@
+package fr.sacane.jmanager.application.bus
+
+import fr.sacane.jmanager.domain.port.input.Query
+import fr.sacane.jmanager.domain.utils.Result
+import org.slf4j.LoggerFactory
+import org.springframework.context.annotation.Primary
+import org.springframework.stereotype.Component
+
+/**
+ * Decorator around [SpringQueryBus] that logs every query dispatch.
+ *
+ * Emits one INFO line per dispatch:
+ * ```
+ * QUERY  | FindAllRegisteredBookletsQuery  | OK               |   8 ms
+ * QUERY  | FindBookletByIdQuery            | NOT_FOUND        |   2 ms
+ * ```
+ *
+ * No payload is logged — query fields may contain user data.
+ */
+@Primary
+@Component
+class LoggingQueryBus(
+    private val delegate: SpringQueryBus
+) : QueryBus {
+
+    private val log = LoggerFactory.getLogger(LoggingQueryBus::class.java)
+
+    override fun <R> dispatch(query: Query<R>): Result<R> {
+        val name = query::class.simpleName ?: "UnknownQuery"
+        val start = System.nanoTime()
+        val result = delegate.dispatch(query)
+        val ms = (System.nanoTime() - start) / 1_000_000
+        log.info("QUERY  | {:<50} | {:<30} | {} ms", name, result.status.name, ms)
+        return result
+    }
+}

--- a/application/src/main/kotlin/fr/sacane/jmanager/application/bus/LoggingQueryBus.kt
+++ b/application/src/main/kotlin/fr/sacane/jmanager/application/bus/LoggingQueryBus.kt
@@ -1,20 +1,25 @@
 package fr.sacane.jmanager.application.bus
 
+import fr.sacane.jmanager.domain.port.input.MdcContextProvider
 import fr.sacane.jmanager.domain.port.input.Query
 import fr.sacane.jmanager.domain.utils.Result
 import org.slf4j.LoggerFactory
+import org.slf4j.MDC
 import org.springframework.context.annotation.Primary
 import org.springframework.stereotype.Component
 
 /**
- * Decorator around [SpringQueryBus] that logs every query dispatch.
+ * Decorator around [SpringQueryBus] that:
+ * 1. Injects domain context (bookletId, transactionId) into the SLF4J MDC for the duration
+ *    of the dispatch when the query implements [MdcContextProvider].
+ * 2. Emits one INFO line per dispatch with the query name, result state, and execution time.
  *
- * Emits one INFO line per dispatch:
  * ```
  * QUERY  | FindAllRegisteredBookletsQuery  | OK               |   8 ms
  * QUERY  | FindBookletByIdQuery            | NOT_FOUND        |   2 ms
  * ```
  *
+ * MDC is cleared in a `finally` block — no context leaks across requests.
  * No payload is logged — query fields may contain user data.
  */
 @Primary
@@ -27,10 +32,23 @@ class LoggingQueryBus(
 
     override fun <R> dispatch(query: Query<R>): Result<R> {
         val name = query::class.simpleName ?: "UnknownQuery"
+        val mdcKeys = putMdcContext(query)
         val start = System.nanoTime()
-        val result = delegate.dispatch(query)
-        val ms = (System.nanoTime() - start) / 1_000_000
-        log.info("QUERY  | {:<50} | {:<30} | {} ms", name, result.status.name, ms)
-        return result
+        return try {
+            val result = delegate.dispatch(query)
+            val ms = (System.nanoTime() - start) / 1_000_000
+            log.info("QUERY  | {:<50} | {:<30} | {} ms", name, result.status.name, ms)
+            result
+        } finally {
+            mdcKeys.forEach { MDC.remove(it) }
+        }
+    }
+
+    private fun putMdcContext(query: Query<*>): Set<String> {
+        if (query !is MdcContextProvider) return emptySet()
+        return query.mdcContext()
+            .filterValues { it.isNotBlank() }
+            .also { ctx -> ctx.forEach { (k, v) -> MDC.put(k, v) } }
+            .keys
     }
 }

--- a/application/src/main/kotlin/fr/sacane/jmanager/application/bus/QueryBus.kt
+++ b/application/src/main/kotlin/fr/sacane/jmanager/application/bus/QueryBus.kt
@@ -3,8 +3,8 @@ package fr.sacane.jmanager.application.bus
 import fr.sacane.jmanager.domain.port.input.Query
 import fr.sacane.jmanager.domain.port.input.QueryHandler
 import fr.sacane.jmanager.domain.utils.Result
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
-import java.util.logging.Logger
 
 /**
  * Dispatches a [Query] to the appropriate [QueryHandler].
@@ -17,12 +17,12 @@ interface QueryBus {
 class SpringQueryBus(handlers: List<QueryHandler<*, *>>) : QueryBus {
 
     companion object {
-        private val LOGGER = Logger.getLogger(SpringQueryBus::class.java.name)
+        private val log = LoggerFactory.getLogger(SpringQueryBus::class.java)
     }
 
     private val handlerMap: Map<Class<*>, QueryHandler<*, *>> =
         handlers.associateBy { it.queryClass.java as Class<*> }
-            .also { LOGGER.info("QueryBus initialized with ${it.size} handler(s): ${it.keys.map { k -> k.simpleName }}") }
+            .also { log.info("QueryBus initialized with {} handler(s): {}", it.size, it.keys.map { k -> k.simpleName }) }
 
     @Suppress("UNCHECKED_CAST")
     override fun <R> dispatch(query: Query<R>): Result<R> {

--- a/application/src/main/resources/logback-spring.xml
+++ b/application/src/main/resources/logback-spring.xml
@@ -1,0 +1,158 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration scan="true" scanPeriod="60 seconds">
+
+  <springProfile name="local,test">
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+      <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+        <charset>UTF-8</charset>
+        <pattern>%clr(%d{HH:mm:ss.SSS}){faint} %clr(%-5level){highlight} %clr(%-40.40logger{39}){cyan} %msg%n</pattern>
+      </encoder>
+    </appender>
+
+    <!-- Code métier en DEBUG pour le développement -->
+    <logger name="fr.sacane.jmanager" level="DEBUG"/>
+
+    <!-- SQL visible en local uniquement -->
+    <logger name="org.hibernate.SQL"                         level="DEBUG"/>
+    <logger name="org.hibernate.orm.jdbc.bind"               level="TRACE"/>
+
+    <!-- Spring Web en DEBUG pour voir les mappings/requêtes -->
+    <logger name="org.springframework.web"                   level="DEBUG"/>
+
+    <!-- Flyway en INFO pour suivre les migrations -->
+    <logger name="org.flywaydb"                              level="INFO"/>
+
+    <root level="INFO">
+      <appender-ref ref="CONSOLE"/>
+    </root>
+
+  </springProfile>
+
+
+  <springProfile name="prod">
+
+    <!-- ─────────────────────────────────────────
+         Appender fichier principal : INFO et plus
+         /var/log/jmanager/app.log
+         Max 1 500 MB — rotation quotidienne + 100 MB intra-journalier
+         ───────────────────────────────────────── -->
+    <appender name="FILE_APP" class="ch.qos.logback.core.rolling.RollingFileAppender">
+      <file>/var/log/jmanager/app.log</file>
+
+      <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+        <!-- Archives compressées : économie ~75 % d'espace -->
+        <fileNamePattern>/var/log/jmanager/app.%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
+        <!-- Rotation intra-journalière si le fichier dépasse 100 MB -->
+        <maxFileSize>100MB</maxFileSize>
+        <!-- Conservation 30 jours -->
+        <maxHistory>30</maxHistory>
+        <totalSizeCap>1500MB</totalSizeCap>
+      </rollingPolicy>
+
+      <encoder>
+        <charset>UTF-8</charset>
+        <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level [%thread] %logger{36} - %msg%n</pattern>
+      </encoder>
+
+      <!-- Filtre : INFO et au-dessus uniquement -->
+      <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+        <level>INFO</level>
+      </filter>
+    </appender>
+
+    <!-- ─────────────────────────────────────────
+         Appender erreurs : ERROR uniquement
+         /var/log/jmanager/error.log
+         Max 300 MB — rétention 90 jours (post-mortem)
+         ───────────────────────────────────────── -->
+    <appender name="FILE_ERROR" class="ch.qos.logback.core.rolling.RollingFileAppender">
+      <file>/var/log/jmanager/error.log</file>
+
+      <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+        <fileNamePattern>/var/log/jmanager/error.%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
+        <maxFileSize>50MB</maxFileSize>
+        <!-- 90 jours : les erreurs sont précieuses pour les post-mortems -->
+        <maxHistory>90</maxHistory>
+        <totalSizeCap>300MB</totalSizeCap>
+      </rollingPolicy>
+
+      <encoder>
+        <charset>UTF-8</charset>
+        <!-- Stack trace complète sur les erreurs -->
+        <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level [%thread] %logger{36} - %msg%n%ex{full}</pattern>
+      </encoder>
+
+      <!-- Filtre strict : ERROR uniquement -->
+      <filter class="ch.qos.logback.classic.filter.LevelFilter">
+        <level>ERROR</level>
+        <onMatch>ACCEPT</onMatch>
+        <onMismatch>DENY</onMismatch>
+      </filter>
+    </appender>
+
+    <!-- ─────────────────────────────────────────
+         AsyncAppender — app.log
+         Délègue le flush disque à un thread dédié,
+         libère les threads HTTP Tomcat pendant l'I/O
+         ───────────────────────────────────────── -->
+    <appender name="ASYNC_APP" class="ch.qos.logback.classic.AsyncAppender">
+      <appender-ref ref="FILE_APP"/>
+      <!-- 1024 slots (~8 MB) — négligeable sur 8 GB RAM -->
+      <queueSize>1024</queueSize>
+      <!-- 0 = jamais de discard même si la queue est à 80% — aucune perte de log -->
+      <discardingThreshold>0</discardingThreshold>
+      <!-- false = backpressure sur le thread appelant si queue saturée (pas de perte silencieuse) -->
+      <neverBlock>false</neverBlock>
+      <!-- Caller data (fichier/ligne) coûteux : OFF sur le flux principal -->
+      <includeCallerData>false</includeCallerData>
+    </appender>
+
+    <!-- ─────────────────────────────────────────
+         AsyncAppender — error.log
+         Petite queue (erreurs rares), caller data ON
+         pour avoir le fichier/numéro de ligne dans les erreurs
+         ───────────────────────────────────────── -->
+    <appender name="ASYNC_ERROR" class="ch.qos.logback.classic.AsyncAppender">
+      <appender-ref ref="FILE_ERROR"/>
+      <queueSize>256</queueSize>
+      <discardingThreshold>0</discardingThreshold>
+      <neverBlock>false</neverBlock>
+      <!-- ON : on veut le contexte complet dans error.log -->
+      <includeCallerData>true</includeCallerData>
+    </appender>
+
+    <!-- ─────────────────────────────────────────
+         Niveaux par package
+         ───────────────────────────────────────── -->
+
+    <!-- Code JManager : INFO — les deux fichiers -->
+    <logger name="fr.sacane.jmanager" level="INFO" additivity="false">
+      <appender-ref ref="ASYNC_APP"/>
+      <appender-ref ref="ASYNC_ERROR"/>
+    </logger>
+
+    <!-- Flyway : INFO pour tracer les migrations en prod -->
+    <logger name="org.flywaydb"                              level="INFO"/>
+
+    <!-- Libs bruyantes : WARN -->
+    <logger name="org.hibernate"                             level="WARN"/>
+    <logger name="org.hibernate.SQL"                         level="OFF"/>
+    <logger name="org.hibernate.orm.jdbc.bind"               level="OFF"/>
+    <logger name="org.springframework"                       level="WARN"/>
+    <logger name="org.springframework.security"              level="WARN"/>
+    <logger name="org.springframework.web"                   level="WARN"/>
+    <logger name="com.zaxxer.hikari"                         level="WARN"/>
+    <logger name="org.apache.tomcat"                         level="WARN"/>
+    <logger name="org.apache.catalina"                       level="WARN"/>
+    <logger name="org.apache.coyote"                         level="WARN"/>
+
+    <!-- Root catch-all : WARN -->
+    <root level="WARN">
+      <appender-ref ref="ASYNC_APP"/>
+      <appender-ref ref="ASYNC_ERROR"/>
+    </root>
+
+  </springProfile>
+
+</configuration>

--- a/application/src/main/resources/logback-spring.xml
+++ b/application/src/main/resources/logback-spring.xml
@@ -6,7 +6,8 @@
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
       <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
         <charset>UTF-8</charset>
-        <pattern>%clr(%d{HH:mm:ss.SSS}){faint} %clr(%-5level){highlight} %clr(%-40.40logger{39}){cyan} %msg%n</pattern>
+        <!-- MDC context affiché en jaune uniquement quand présent -->
+        <pattern>%clr(%d{HH:mm:ss.SSS}){faint} %clr(%-5level){highlight} %clr(%-40.40logger{39}){cyan}%clr(%replace( [booklet=%X{bookletId}]){' \[booklet=\]', ''}){yellow}%clr(%replace( [tx=%X{transactionId}]){' \[tx=\]', ''}){yellow} %msg%n</pattern>
       </encoder>
     </appender>
 
@@ -52,7 +53,8 @@
 
       <encoder>
         <charset>UTF-8</charset>
-        <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level [%thread] %logger{36} - %msg%n</pattern>
+        <!-- MDC context injecté conditionnellement entre le logger et le message -->
+        <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level [%thread] %logger{36}%replace( [booklet=%X{bookletId}]){' \[booklet=\]', ''}%replace( [tx=%X{transactionId}]){' \[tx=\]', ''} - %msg%n</pattern>
       </encoder>
 
       <!-- Filtre : INFO et au-dessus uniquement -->
@@ -79,8 +81,8 @@
 
       <encoder>
         <charset>UTF-8</charset>
-        <!-- Stack trace complète sur les erreurs -->
-        <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level [%thread] %logger{36} - %msg%n%ex{full}</pattern>
+        <!-- MDC context + stack trace complète sur les erreurs -->
+        <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level [%thread] %logger{36}%replace( [booklet=%X{bookletId}]){' \[booklet=\]', ''}%replace( [tx=%X{transactionId}]){' \[tx=\]', ''} - %msg%n%ex{full}</pattern>
       </encoder>
 
       <!-- Filtre strict : ERROR uniquement -->

--- a/docs/technical/bus-logging/2026-05-25-command-query-dispatch-logging.md
+++ b/docs/technical/bus-logging/2026-05-25-command-query-dispatch-logging.md
@@ -1,0 +1,193 @@
+# Command/Query Dispatch Logging
+
+> **Topic**: Observability — Bus-level tracing
+> **Date**: 2026-05-25
+> **Author**: Technical Backend
+
+---
+
+## Context
+
+JManager uses a Command/Query bus pattern to dispatch write and read operations to their respective handlers.
+Currently no individual dispatch is logged, making it impossible to trace which operations were executed, how long
+they took, or whether they succeeded. Adding generic logging at the bus level provides a single cross-cutting
+observation point without touching any handler or controller.
+
+---
+
+## Current State
+
+### `SpringCommandBus` / `SpringQueryBus` — two problems
+
+**Problem 1 — `java.util.logging.Logger` instead of SLF4J**
+
+Both buses use the JDK logger:
+```kotlin
+private val LOGGER = Logger.getLogger(SpringCommandBus::class.java.name)
+```
+
+Spring Boot includes the `jul-to-slf4j` bridge, so logs do flow through Logback eventually — but:
+- The SLF4J parameterized syntax (`{}`) is unavailable, so string concatenation is used instead.
+- Log levels don't map cleanly (JUL `INFO` ≠ SLF4J `INFO` after bridging).
+- The `logback-spring.xml` logger name filters work on SLF4J logger names, not JUL names.
+
+**Problem 2 — No per-dispatch logging**
+
+`dispatch()` in both buses contains zero logging. There is no way to know post-hoc:
+- Which command/query was executed
+- Whether it succeeded or failed (and with which `ResultState`)
+- How long the handler took
+
+---
+
+## Analysis
+
+### Option A — Modify `dispatch()` directly
+
+Add `INFO` logging inside the existing `dispatch()` methods. Simple, zero new files.
+
+**Rejected** — mixes the dispatch responsibility (routing) with the observability concern (logging).
+Violates SRP. Also makes it harder to later add metrics or MDC enrichment without touching the router.
+
+### Option B — Spring AOP `@Around` advice
+
+Intercept `CommandBus.dispatch()` and `QueryBus.dispatch()` via a pointcut.
+
+**Rejected** — AOP proxy-based magic is harder to trace during debugging and adds CGLIB complexity.
+The bus classes are not Spring beans requiring transparent interception; they are owned infrastructure
+where the Decorator is explicit and readable.
+
+### Option C — Decorator pattern ✅ (recommended)
+
+Create `LoggingCommandBus` and `LoggingQueryBus`, each implementing the respective bus interface and
+delegating to the real implementation. Spring wires the decorator as `@Primary`.
+
+**Chosen** because:
+- Single Responsibility: the decorator owns logging, the real bus owns routing.
+- Explicit: the delegation chain is visible in code.
+- Extensible: adding MDC enrichment or Micrometer timing later means touching only the decorator.
+- Zero domain contamination: purely in the `application` layer.
+
+### What to log
+
+Each dispatch emits one `INFO` log line:
+
+```
+COMMAND dispatched | SaveBookletCommand          | OK              |  12 ms
+COMMAND dispatched | DeleteBookletByIdCommand    | BOOKLET_NOT_FOUND |   3 ms
+QUERY  dispatched  | FindAllBookletsQuery         | OK              |   8 ms
+QUERY  dispatched  | FindBookletByIdQuery         | NOT_FOUND       |   2 ms
+```
+
+- **Command/Query name**: `command::class.simpleName` — sufficient for tracing, no sensitive data.
+- **Result state**: `result.status.name` — maps to `ResultState` enum, always meaningful.
+- **Duration**: wall-clock ms via `System.nanoTime()` — measures handler execution only.
+
+No payload logging: command/query fields may contain user data (amounts, labels). Logging them
+would be a privacy concern and would bloat logs.
+
+---
+
+## Recommended Approach
+
+### 1. Fix `SpringCommandBus` and `SpringQueryBus` — switch to SLF4J
+
+Replace `java.util.logging.Logger` with `org.slf4j.LoggerFactory` in both buses.
+No dependency change needed: `slf4j-api` is already on the classpath via `spring-boot-starter-web`.
+
+### 2. Create `LoggingCommandBus` and `LoggingQueryBus`
+
+Decorators in `application/src/main/kotlin/fr/sacane/jmanager/application/bus/`.
+Annotated `@Primary` so Spring injects them wherever `CommandBus`/`QueryBus` is needed.
+They inject the concrete `SpringCommandBus` / `SpringQueryBus` directly to avoid circular dependency.
+
+### Why this approach
+
+The buses are pure application infrastructure. The decorator keeps the routing logic untouched and
+creates a named, testable seam for observability. If Micrometer metrics are added later, the decorator
+absorbs them without touching `SpringCommandBus`.
+
+---
+
+## Implementation Notes
+
+### Files to modify
+
+| File | Change |
+|---|---|
+| `application/…/bus/CommandBus.kt` | Replace JUL logger with SLF4J |
+| `application/…/bus/QueryBus.kt` | Replace JUL logger with SLF4J |
+
+### Files to create
+
+| File | Role |
+|---|---|
+| `application/…/bus/LoggingCommandBus.kt` | Decorator — logs command dispatches |
+| `application/…/bus/LoggingQueryBus.kt` | Decorator — logs query dispatches |
+
+### No new dependencies
+
+`slf4j-api` is transitively provided by `spring-boot-starter-web`. No `build.gradle.kts` change needed.
+
+### Code
+
+**`LoggingCommandBus.kt`**
+```kotlin
+@Component
+@Primary
+class LoggingCommandBus(
+    private val delegate: SpringCommandBus
+) : CommandBus {
+
+    private val log = LoggerFactory.getLogger(LoggingCommandBus::class.java)
+
+    override fun <R> dispatch(command: Command<R>): Result<R> {
+        val name = command::class.simpleName ?: "UnknownCommand"
+        val start = System.nanoTime()
+        val result = delegate.dispatch(command)
+        val ms = (System.nanoTime() - start) / 1_000_000
+        log.info("COMMAND dispatched | {:<45} | {:<30} | {} ms", name, result.status.name, ms)
+        return result
+    }
+}
+```
+
+**`LoggingQueryBus.kt`**
+```kotlin
+@Component
+@Primary
+class LoggingQueryBus(
+    private val delegate: SpringQueryBus
+) : QueryBus {
+
+    private val log = LoggerFactory.getLogger(LoggingQueryBus::class.java)
+
+    override fun <R> dispatch(query: Query<R>): Result<R> {
+        val name = query::class.simpleName ?: "UnknownQuery"
+        val start = System.nanoTime()
+        val result = delegate.dispatch(query)
+        val ms = (System.nanoTime() - start) / 1_000_000
+        log.info("QUERY  dispatched | {:<45} | {:<30} | {} ms", name, result.status.name, ms)
+        return result
+    }
+}
+```
+
+---
+
+## Trade-offs & Risks
+
+| Concern | Impact | Mitigation |
+|---|---|---|
+| Two beans of same type in Spring context | Low | `@Primary` on decorators ensures correct injection; `SpringCommandBus` is only injected explicitly in the decorator |
+| `simpleName` is null for anonymous classes | Low | Fallback to `"UnknownCommand"` / `"UnknownQuery"` via Elvis operator |
+| Logging every dispatch in prod (high-traffic) | Low | `INFO` level on `fr.sacane.jmanager` is already the configured minimum in `logback-spring.xml`; bus logs are one line per request, negligible volume for a small SaaS |
+| No payload logging | Intentional | Privacy — command fields may contain user data |
+
+---
+
+## References
+
+- [SLF4J Manual — Logger usage](https://www.slf4j.org/manual.html)
+- [Decorator pattern — GoF](https://refactoring.guru/design-patterns/decorator)
+- [Spring `@Primary` bean qualifier](https://docs.spring.io/spring-framework/docs/current/reference/html/core.html#beans-primary)

--- a/domain/build.gradle.kts
+++ b/domain/build.gradle.kts
@@ -8,6 +8,9 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
 
+    // Logging facade — pure API, no implementation pulled in
+    implementation("org.slf4j:slf4j-api:2.0.16")
+
     implementation("at.favre.lib", "bcrypt", bcryptVersion)
 
     testImplementation("org.junit.jupiter:junit-jupiter:5.10.0")

--- a/domain/src/main/kotlin/fr/sacane/jmanager/domain/port/input/MdcContext.kt
+++ b/domain/src/main/kotlin/fr/sacane/jmanager/domain/port/input/MdcContext.kt
@@ -1,0 +1,26 @@
+package fr.sacane.jmanager.domain.port.input
+
+/**
+ * Implemented by [Command] and [Query] objects that carry identifiable domain context
+ * (booklet ID, transaction ID, etc.).
+ *
+ * The bus infrastructure reads [mdcContext] before dispatch and injects the entries into
+ * the SLF4J MDC so that every log line produced during the operation includes them.
+ * The MDC is cleared in a `finally` block after dispatch — the domain never touches MDC directly.
+ */
+interface MdcContextProvider {
+    /**
+     * Returns the key-value pairs to inject into the MDC for the duration of this dispatch.
+     * Use [MdcKeys] constants as keys for consistency.
+     * Empty entries (blank values) are ignored by the bus.
+     */
+    fun mdcContext(): Map<String, String>
+}
+
+/**
+ * Canonical MDC key names shared by all commands, queries, and the Logback pattern.
+ */
+object MdcKeys {
+    const val BOOKLET_ID = "bookletId"
+    const val TRANSACTION_ID = "transactionId"
+}

--- a/domain/src/main/kotlin/fr/sacane/jmanager/domain/port/input/booklet/DeleteBookletByIdUseCase.kt
+++ b/domain/src/main/kotlin/fr/sacane/jmanager/domain/port/input/booklet/DeleteBookletByIdUseCase.kt
@@ -13,6 +13,7 @@ import fr.sacane.jmanager.domain.utils.Result
 import fr.sacane.jmanager.domain.utils.ResultState
 import fr.sacane.jmanager.domain.utils.success
 import java.util.UUID
+import org.slf4j.LoggerFactory
 
 data class DeleteBookletByIdCommand(
     val bookletId: UUID,
@@ -30,6 +31,11 @@ class DeleteBookletByIdService(
     private val unitOfWorkTransactionProviderPort: UnitOfWorkTransactionProvider,
     private val trackerRepository: RegularTransactionTrackerRepository
 ) : DeleteBookletByIdUseCase {
+
+    companion object {
+        private val log = LoggerFactory.getLogger(DeleteBookletByIdService::class.java)
+    }
+
     override fun handle(command: DeleteBookletByIdCommand): Result<Nothing> {
         val userId = command.userId
         val bookletId = command.bookletId
@@ -50,6 +56,7 @@ class DeleteBookletByIdService(
             }
             bookletRepository.deleteBookletById(bookletId)
             trackerRepository.deleteTrackerByBookletId(bookletId)
+            log.info("Booklet deleted: id={}", bookletId)
             return@executeInTransaction success()
         }
     }

--- a/domain/src/main/kotlin/fr/sacane/jmanager/domain/port/input/booklet/DeleteBookletByIdUseCase.kt
+++ b/domain/src/main/kotlin/fr/sacane/jmanager/domain/port/input/booklet/DeleteBookletByIdUseCase.kt
@@ -9,6 +9,8 @@ import fr.sacane.jmanager.domain.port.output.repository.RegularTransactionTracke
 import fr.sacane.jmanager.domain.port.output.repository.UnitOfWorkTransactionProvider
 import fr.sacane.jmanager.domain.port.input.Command
 import fr.sacane.jmanager.domain.port.input.CommandHandler
+import fr.sacane.jmanager.domain.port.input.MdcContextProvider
+import fr.sacane.jmanager.domain.port.input.MdcKeys
 import fr.sacane.jmanager.domain.utils.Result
 import fr.sacane.jmanager.domain.utils.ResultState
 import fr.sacane.jmanager.domain.utils.success
@@ -18,7 +20,9 @@ import org.slf4j.LoggerFactory
 data class DeleteBookletByIdCommand(
     val bookletId: UUID,
     val userId: UserId
-) : Command<Nothing>
+) : Command<Nothing>, MdcContextProvider {
+    override fun mdcContext() = mapOf(MdcKeys.BOOKLET_ID to bookletId.toString())
+}
 
 @Port(Side.APPLICATION)
 interface DeleteBookletByIdUseCase : CommandHandler<DeleteBookletByIdCommand, Nothing> {

--- a/domain/src/main/kotlin/fr/sacane/jmanager/domain/port/input/booklet/EditBookletUseCase.kt
+++ b/domain/src/main/kotlin/fr/sacane/jmanager/domain/port/input/booklet/EditBookletUseCase.kt
@@ -8,6 +8,8 @@ import fr.sacane.jmanager.domain.models.UserId
 import fr.sacane.jmanager.domain.port.output.repository.BookletRepository
 import fr.sacane.jmanager.domain.port.input.Command
 import fr.sacane.jmanager.domain.port.input.CommandHandler
+import fr.sacane.jmanager.domain.port.input.MdcContextProvider
+import fr.sacane.jmanager.domain.port.input.MdcKeys
 import fr.sacane.jmanager.domain.utils.Result
 import fr.sacane.jmanager.domain.utils.ResultState
 import fr.sacane.jmanager.domain.utils.success
@@ -15,7 +17,11 @@ import fr.sacane.jmanager.domain.utils.success
 data class EditBookletCommand(
     val booklet: Booklet,
     val userId: UserId
-) : Command<Booklet>
+) : Command<Booklet>, MdcContextProvider {
+    override fun mdcContext() = buildMap {
+        booklet.id?.let { put(MdcKeys.BOOKLET_ID, it.toString()) }
+    }
+}
 
 @Port(Side.APPLICATION)
 interface EditBookletUseCase : CommandHandler<EditBookletCommand, Booklet> {

--- a/domain/src/main/kotlin/fr/sacane/jmanager/domain/port/input/booklet/FindBookletByIdUseCase.kt
+++ b/domain/src/main/kotlin/fr/sacane/jmanager/domain/port/input/booklet/FindBookletByIdUseCase.kt
@@ -6,6 +6,8 @@ import fr.sacane.jmanager.domain.hexadoc.Side
 import fr.sacane.jmanager.domain.models.Booklet
 import fr.sacane.jmanager.domain.models.UserId
 import fr.sacane.jmanager.domain.port.output.repository.BookletRepository
+import fr.sacane.jmanager.domain.port.input.MdcContextProvider
+import fr.sacane.jmanager.domain.port.input.MdcKeys
 import fr.sacane.jmanager.domain.port.input.Query
 import fr.sacane.jmanager.domain.port.input.QueryHandler
 import fr.sacane.jmanager.domain.utils.Result
@@ -16,7 +18,9 @@ import java.util.UUID
 data class FindBookletByIdQuery(
     val bookletId: UUID,
     val userId: UserId
-) : Query<Booklet>
+) : Query<Booklet>, MdcContextProvider {
+    override fun mdcContext() = mapOf(MdcKeys.BOOKLET_ID to bookletId.toString())
+}
 
 @Port(Side.APPLICATION)
 interface FindBookletByIdUseCase : QueryHandler<FindBookletByIdQuery, Booklet> {

--- a/domain/src/main/kotlin/fr/sacane/jmanager/domain/port/input/booklet/LoadBalancesForBookletForAMonthUseCase.kt
+++ b/domain/src/main/kotlin/fr/sacane/jmanager/domain/port/input/booklet/LoadBalancesForBookletForAMonthUseCase.kt
@@ -12,6 +12,8 @@ import fr.sacane.jmanager.domain.port.output.repository.RegularTransactionReposi
 import fr.sacane.jmanager.domain.port.output.repository.TransactionQueryRepository
 import fr.sacane.jmanager.domain.port.output.repository.UnitOfWorkTransactionProvider
 import fr.sacane.jmanager.domain.usecase.RegularTransactionGenerator
+import fr.sacane.jmanager.domain.port.input.MdcContextProvider
+import fr.sacane.jmanager.domain.port.input.MdcKeys
 import fr.sacane.jmanager.domain.port.input.Query
 import fr.sacane.jmanager.domain.port.input.QueryHandler
 import fr.sacane.jmanager.domain.utils.Result
@@ -31,7 +33,9 @@ data class LoadBalancesForBookletForAMonthQuery(
     val startingYear: Int? = null,
     val startDate: LocalDate? = null,
     val endDate: LocalDate? = null,
-) : Query<BookletBalances>
+) : Query<BookletBalances>, MdcContextProvider {
+    override fun mdcContext() = mapOf(MdcKeys.BOOKLET_ID to bookletId.toString())
+}
 
 @Port(Side.APPLICATION)
 interface LoadBalancesForBookletForAMonthUseCase : QueryHandler<LoadBalancesForBookletForAMonthQuery, BookletBalances> {

--- a/domain/src/main/kotlin/fr/sacane/jmanager/domain/port/input/booklet/LoadTransactionsForBookletForAMonthUseCase.kt
+++ b/domain/src/main/kotlin/fr/sacane/jmanager/domain/port/input/booklet/LoadTransactionsForBookletForAMonthUseCase.kt
@@ -13,6 +13,8 @@ import fr.sacane.jmanager.domain.port.output.repository.RegularTransactionTracke
 import fr.sacane.jmanager.domain.port.output.repository.TransactionQueryRepository
 import fr.sacane.jmanager.domain.port.output.repository.UnitOfWorkTransactionProvider
 import fr.sacane.jmanager.domain.usecase.RegularTransactionGenerator
+import fr.sacane.jmanager.domain.port.input.MdcContextProvider
+import fr.sacane.jmanager.domain.port.input.MdcKeys
 import fr.sacane.jmanager.domain.port.input.Query
 import fr.sacane.jmanager.domain.port.input.QueryHandler
 import fr.sacane.jmanager.domain.utils.Result
@@ -23,7 +25,7 @@ import java.time.LocalDate
 import java.time.Month
 import java.time.YearMonth
 import java.util.UUID
-import java.util.logging.Logger
+import org.slf4j.LoggerFactory
 
 data class LoadTransactionsForBookletForAMonthQuery(
     val userId: UserId,
@@ -36,7 +38,9 @@ data class LoadTransactionsForBookletForAMonthQuery(
     val endDate: LocalDate? = null,
     val pageNumber: Int = 0,
     val pageSize: Int = 10,
-) : Query<BookletLoadingResult>
+) : Query<BookletLoadingResult>, MdcContextProvider {
+    override fun mdcContext() = mapOf(MdcKeys.BOOKLET_ID to bookletId.toString())
+}
 
 @Port(Side.APPLICATION)
 interface LoadTransactionsForBookletForAMonthUseCase : QueryHandler<LoadTransactionsForBookletForAMonthQuery, BookletLoadingResult> {
@@ -55,14 +59,14 @@ class LoadTransactionsForBookletForAMonthService(
 ) : LoadTransactionsForBookletForAMonthUseCase {
 
     companion object {
-        private val LOGGER = Logger.getLogger(LoadTransactionsForBookletForAMonthService::class.java.name)
+        private val log = LoggerFactory.getLogger(LoadTransactionsForBookletForAMonthService::class.java)
     }
 
     override fun handle(query: LoadTransactionsForBookletForAMonthQuery): Result<BookletLoadingResult> {
         val (userId, bookletId, month, year, startingMonth, startingYear, startDate, endDate, pageNumber, pageSize) = query
         return unitOfWorkTransactionProviderPort.executeInTransaction(Unit) {
             val totalStartNs = System.nanoTime()
-            LOGGER.info("Loading transactions for booklet $bookletId for month $month and year $year")
+            log.info("Loading transactions for {}/{}", month, year)
 
             val fetchBookletStartNs = System.nanoTime()
             val booklet: Booklet = bookletRepository.findBookletByIdWithTransactions(bookletId)
@@ -71,7 +75,7 @@ class LoadTransactionsForBookletForAMonthService(
                     "Requested booklet is not registered",
                     "domain.booklet.load_transactions.not_found"
                 )
-            LOGGER.info { "Fetched booklet: ${booklet.label} (${booklet.id})" }
+            log.info("Fetched booklet: label={}", booklet.label)
             val fetchBookletMs = Duration.ofNanos(System.nanoTime() - fetchBookletStartNs).toMillis()
 
             val fetchRegularStartNs = System.nanoTime()
@@ -116,7 +120,7 @@ class LoadTransactionsForBookletForAMonthService(
                     month,
                     year
                 )
-                LOGGER.info("Generated ${transactions.size} physical transactions for current month $month/$year")
+                log.info("Generated {} physical transactions for current month {}/{}", transactions.size, month, year)
                 transactions.size
             } else if (hasExplicitDateRange) {
                 if (!today.isBefore(resolvedRangeStart) && !YearMonth.from(today).isAfter(YearMonth.from(resolvedRangeEnd))) {
@@ -138,14 +142,14 @@ class LoadTransactionsForBookletForAMonthService(
                         generated += transactions.size
                         ym = ym.plusMonths(1)
                     }
-                    LOGGER.info("Generated $generated physical transactions for custom-range current period $resolvedRangeStart..$resolvedRangeEnd")
+                    log.info("Generated {} physical transactions for custom range {}..{}", generated, resolvedRangeStart, resolvedRangeEnd)
                     generated
                 } else {
-                    LOGGER.info("Skipping physical generation for custom-range non-current period $resolvedRangeStart..$resolvedRangeEnd")
+                    log.info("Skipping generation for non-current custom range {}..{}", resolvedRangeStart, resolvedRangeEnd)
                     0
                 }
             } else {
-                LOGGER.info("Skipping physical transaction generation for non-current month $month/$year")
+                log.info("Skipping generation for non-current month {}/{}", month, year)
                 0
             }
             val generationMs = Duration.ofNanos(System.nanoTime() - generationStartNs).toMillis()
@@ -269,14 +273,13 @@ class LoadTransactionsForBookletForAMonthService(
             )
 
             val totalMs = Duration.ofNanos(System.nanoTime() - totalStartNs).toMillis()
-            LOGGER.info(
-                """
-                Booklet loaded successfully:
-                - bookletId: $bookletId
-                - period: $month/$year (range=$resolvedRangeStart..$resolvedRangeEnd)
-                - sizes: monthTransactions=${allTransactionsForPeriod.size}, current=${transactions.second.size}, preview=${transactions.first.size}, virtualPreview=${virtualTransactionsForTargetPeriod.size}, regular=${regularTransactions.size}, trackers=${trackersByRegularId.size}
-                - timings(ms): fetchBooklet=$fetchBookletMs, fetchRegular=$fetchRegularMs, generate=$generationMs (generated=$generatedCount), updateBooklet=$updateBookletMs, monthQuery=$monthTransactionMs, preloadTrackers=$preloadTrackersMs, filterExcluded=$filterExcludedMs, previsionalSold=$previsionalMs, total=$totalMs
-                """.trimIndent()
+            log.info(
+                "Booklet loaded: period={}/{} range={}..{} | sizes: month={} current={} preview={} virtual={} regular={} trackers={} | timings(ms): fetchBooklet={} fetchRegular={} generate={}(n={}) monthQuery={} trackers={} filterExcluded={} previsional={} total={}",
+                month, year, resolvedRangeStart, resolvedRangeEnd,
+                allTransactionsForPeriod.size, transactions.second.size, transactions.first.size,
+                virtualTransactionsForTargetPeriod.size, regularTransactions.size, trackersByRegularId.size,
+                fetchBookletMs, fetchRegularMs, generationMs, generatedCount,
+                monthTransactionMs, preloadTrackersMs, filterExcludedMs, previsionalMs, totalMs
             )
 
             return@executeInTransaction success(bookletLoadingResult)

--- a/domain/src/main/kotlin/fr/sacane/jmanager/domain/port/input/booklet/RegenerateDeletedPrevisionalTransactionsUseCase.kt
+++ b/domain/src/main/kotlin/fr/sacane/jmanager/domain/port/input/booklet/RegenerateDeletedPrevisionalTransactionsUseCase.kt
@@ -13,6 +13,8 @@ import fr.sacane.jmanager.domain.port.output.repository.UnitOfWorkTransactionPro
 import fr.sacane.jmanager.domain.usecase.RegularTransactionGenerator
 import fr.sacane.jmanager.domain.port.input.Command
 import fr.sacane.jmanager.domain.port.input.CommandHandler
+import fr.sacane.jmanager.domain.port.input.MdcContextProvider
+import fr.sacane.jmanager.domain.port.input.MdcKeys
 import fr.sacane.jmanager.domain.utils.Result
 import fr.sacane.jmanager.domain.utils.ResultState
 import fr.sacane.jmanager.domain.utils.success
@@ -26,7 +28,9 @@ data class RegenerateDeletedPrevisionalTransactionsCommand(
     val bookletId: UUID,
     val month: Month,
     val year: Int
-) : Command<List<Transaction>>
+) : Command<List<Transaction>>, MdcContextProvider {
+    override fun mdcContext() = mapOf(MdcKeys.BOOKLET_ID to bookletId.toString())
+}
 
 @Port(Side.APPLICATION)
 interface RegenerateDeletedPrevisionalTransactionsUseCase : CommandHandler<RegenerateDeletedPrevisionalTransactionsCommand, List<Transaction>> {

--- a/domain/src/main/kotlin/fr/sacane/jmanager/domain/port/input/csv/ImportTransactionsFromCsvUseCase.kt
+++ b/domain/src/main/kotlin/fr/sacane/jmanager/domain/port/input/csv/ImportTransactionsFromCsvUseCase.kt
@@ -19,7 +19,7 @@ import fr.sacane.jmanager.domain.utils.Result
 import fr.sacane.jmanager.domain.utils.ResultState
 import fr.sacane.jmanager.domain.utils.success
 import java.util.UUID
-import java.util.logging.Logger
+import org.slf4j.LoggerFactory
 
 data class ImportTransactionsFromCsvCommand(
     val userId: UserId,
@@ -45,7 +45,7 @@ class ImportTransactionsFromCsvService(
 ) : ImportTransactionsFromCsvUseCase {
 
     companion object {
-        private val logger = Logger.getLogger(ImportTransactionsFromCsvService::class.java.name)
+        private val log = LoggerFactory.getLogger(ImportTransactionsFromCsvService::class.java)
     }
 
     private val validator = CsvTransactionValidator()
@@ -71,12 +71,12 @@ class ImportTransactionsFromCsvService(
                         val results = convertRowsToTransactions(validator, rows, userTags, command.skipValidation, command.month, command.year)
                         val csvImportResult = saveTransactions(transactionRepository, bookletRepository, bookletParam, results)
 
-                        logger.info("CSV import completed: ${csvImportResult.successCount} transactions imported, ${csvImportResult.failedLines.size} errors")
+                        log.info("CSV import completed: {} transactions imported, {} failures", csvImportResult.successCount, csvImportResult.failedLines.size)
                     success(csvImportResult)
                 }
             }
         } catch (e: Exception) {
-            logger.severe("Error during CSV import: ${e.message}")
+            log.error("CSV import failed unexpectedly", e)
             return csvDomainFailure(
                 ResultState.INTERNAL_SERVER_ERROR,
                 "Error during import: ${e.message}",

--- a/domain/src/main/kotlin/fr/sacane/jmanager/domain/port/input/csv/ImportTransactionsFromCsvUseCase.kt
+++ b/domain/src/main/kotlin/fr/sacane/jmanager/domain/port/input/csv/ImportTransactionsFromCsvUseCase.kt
@@ -15,6 +15,8 @@ import fr.sacane.jmanager.domain.usecase.csv.CsvTransactionValidator
 import fr.sacane.jmanager.domain.usecase.csv.CsvValidationUtils
 import fr.sacane.jmanager.domain.port.input.Command
 import fr.sacane.jmanager.domain.port.input.CommandHandler
+import fr.sacane.jmanager.domain.port.input.MdcContextProvider
+import fr.sacane.jmanager.domain.port.input.MdcKeys
 import fr.sacane.jmanager.domain.utils.Result
 import fr.sacane.jmanager.domain.utils.ResultState
 import fr.sacane.jmanager.domain.utils.success
@@ -28,7 +30,9 @@ data class ImportTransactionsFromCsvCommand(
     val skipValidation: Boolean = false,
     val month: Int? = null,
     val year: Int? = null
-) : Command<CsvImportResult>
+) : Command<CsvImportResult>, MdcContextProvider {
+    override fun mdcContext() = mapOf(MdcKeys.BOOKLET_ID to bookletId.toString())
+}
 
 @Port(Side.APPLICATION)
 interface ImportTransactionsFromCsvUseCase : CommandHandler<ImportTransactionsFromCsvCommand, CsvImportResult> {

--- a/domain/src/main/kotlin/fr/sacane/jmanager/domain/port/input/tag/DeleteTagUseCase.kt
+++ b/domain/src/main/kotlin/fr/sacane/jmanager/domain/port/input/tag/DeleteTagUseCase.kt
@@ -11,6 +11,7 @@ import fr.sacane.jmanager.domain.port.input.Command
 import fr.sacane.jmanager.domain.port.input.CommandHandler
 import fr.sacane.jmanager.domain.utils.*
 import java.util.UUID
+import org.slf4j.LoggerFactory
 
 data class DeleteTagCommand(
     val userId: UserId,
@@ -29,6 +30,10 @@ class DeleteTagService(
     private val transactionRepository: TransactionRepository,
     private val regularTransactionRepository: RegularTransactionRepository
 ) : DeleteTagUseCase {
+
+    companion object {
+        private val log = LoggerFactory.getLogger(DeleteTagService::class.java)
+    }
 
     private fun <S> domainFailure(state: ResultState, detail: String, key: String): Result<S> {
         return failure(state, DomainError(state.code, key, detail))
@@ -49,6 +54,7 @@ class DeleteTagService(
             )
         }
         if (command.force && (isUsedInTransactions || isUsedInRegular)) {
+            log.warn("Force-deleting tag in use — replacing with default: tagId={}, subTags={}", command.tagId, allTagIds.size)
             val defaultTag = tagRepository.defaultTag()
             for (tagId in allTagIds) {
                 if (transactionRepository.isPersonalTagUsed(tagId)) {

--- a/domain/src/main/kotlin/fr/sacane/jmanager/domain/port/input/transaction/BookTransactionUseCase.kt
+++ b/domain/src/main/kotlin/fr/sacane/jmanager/domain/port/input/transaction/BookTransactionUseCase.kt
@@ -13,7 +13,7 @@ import fr.sacane.jmanager.domain.port.output.repository.UnitOfWorkTransactionPro
 import fr.sacane.jmanager.domain.port.input.Command
 import fr.sacane.jmanager.domain.port.input.CommandHandler
 import fr.sacane.jmanager.domain.utils.*
-import java.util.logging.Logger
+import org.slf4j.LoggerFactory
 
 data class BookTransactionCommand(
     val userId: UserId,
@@ -35,13 +35,12 @@ class BookTransactionService(
 ) : BookTransactionUseCase {
 
     companion object {
-        private val logger = Logger.getLogger(BookTransactionService::class.java.name)
+        private val log = LoggerFactory.getLogger(BookTransactionService::class.java)
     }
 
     override fun handle(command: BookTransactionCommand): Result<TransactionResumeResult> {
         val userId = command.userId
         return infraTransactionManager.executeInTransaction(command.transaction) {
-            logger.info("Request for a transaction with id $userId")
             if (command.transaction.amount.isNegative()) {
                 return@executeInTransaction domainFailure(
                     ResultState.TRANSACTION_ENTRY_ERROR,
@@ -66,7 +65,7 @@ class BookTransactionService(
             } else newTr
             booklet.addTransaction(toSaveTransaction)
             bookletRepository.update(booklet)
-            logger.info("Transaction $toSaveTransaction has been created, the booklet sold has been updated : $booklet")
+            log.info("Transaction created: id={}, bookletId={}", toSaveTransaction.id, booklet.id)
             success(TransactionResumeResult(toSaveTransaction, booklet.amount))
         }
     }

--- a/domain/src/main/kotlin/fr/sacane/jmanager/domain/port/input/transaction/ConfirmPreviewTransactionUseCase.kt
+++ b/domain/src/main/kotlin/fr/sacane/jmanager/domain/port/input/transaction/ConfirmPreviewTransactionUseCase.kt
@@ -11,6 +11,8 @@ import fr.sacane.jmanager.domain.port.output.repository.TransactionRepository
 import fr.sacane.jmanager.domain.port.output.repository.UnitOfWorkTransactionProvider
 import fr.sacane.jmanager.domain.port.input.Command
 import fr.sacane.jmanager.domain.port.input.CommandHandler
+import fr.sacane.jmanager.domain.port.input.MdcContextProvider
+import fr.sacane.jmanager.domain.port.input.MdcKeys
 import fr.sacane.jmanager.domain.utils.*
 import java.time.LocalDate
 import java.util.UUID
@@ -21,7 +23,12 @@ data class ConfirmPreviewTransactionCommand(
     val transactionId: UUID,
     val newAmount: Amount? = null,
     val newDate: LocalDate? = null
-) : Command<TransactionResumeResult>
+) : Command<TransactionResumeResult>, MdcContextProvider {
+    override fun mdcContext() = mapOf(
+        MdcKeys.BOOKLET_ID to bookletID.toString(),
+        MdcKeys.TRANSACTION_ID to transactionId.toString()
+    )
+}
 
 @Port(Side.APPLICATION)
 interface ConfirmPreviewTransactionUseCase : CommandHandler<ConfirmPreviewTransactionCommand, TransactionResumeResult> {

--- a/domain/src/main/kotlin/fr/sacane/jmanager/domain/port/input/transaction/ConfirmVirtualTransactionUseCase.kt
+++ b/domain/src/main/kotlin/fr/sacane/jmanager/domain/port/input/transaction/ConfirmVirtualTransactionUseCase.kt
@@ -11,6 +11,8 @@ import fr.sacane.jmanager.domain.models.transaction.Transaction
 import fr.sacane.jmanager.domain.models.transaction.regular.RegularTransactionId
 import fr.sacane.jmanager.domain.port.input.Command
 import fr.sacane.jmanager.domain.port.input.CommandHandler
+import fr.sacane.jmanager.domain.port.input.MdcContextProvider
+import fr.sacane.jmanager.domain.port.input.MdcKeys
 import fr.sacane.jmanager.domain.port.output.repository.BookletRepository
 import fr.sacane.jmanager.domain.port.output.repository.RegularTransactionTrackerRepository
 import fr.sacane.jmanager.domain.port.output.repository.TransactionRepository
@@ -30,7 +32,9 @@ data class ConfirmVirtualTransactionCommand(
     val date: LocalDate,
     val isIncome: Boolean,
     val tag: Tag? = null
-) : Command<TransactionResumeResult>
+) : Command<TransactionResumeResult>, MdcContextProvider {
+    override fun mdcContext() = mapOf(MdcKeys.BOOKLET_ID to bookletId.toString())
+}
 
 @Port(Side.APPLICATION)
 interface ConfirmVirtualTransactionUseCase : CommandHandler<ConfirmVirtualTransactionCommand, TransactionResumeResult> {

--- a/domain/src/main/kotlin/fr/sacane/jmanager/domain/port/input/transaction/DeleteTransactionsByIdsUseCase.kt
+++ b/domain/src/main/kotlin/fr/sacane/jmanager/domain/port/input/transaction/DeleteTransactionsByIdsUseCase.kt
@@ -14,7 +14,7 @@ import fr.sacane.jmanager.domain.port.input.Command
 import fr.sacane.jmanager.domain.port.input.CommandHandler
 import fr.sacane.jmanager.domain.utils.*
 import java.util.UUID
-import java.util.logging.Logger
+import org.slf4j.LoggerFactory
 
 data class DeleteTransactionsByIdsCommand(
     val userId: UserId,
@@ -36,7 +36,7 @@ class DeleteTransactionsByIdsService(
 ) : DeleteTransactionsByIdsUseCase {
 
     companion object {
-        private val logger = Logger.getLogger(DeleteTransactionsByIdsService::class.java.name)
+        private val log = LoggerFactory.getLogger(DeleteTransactionsByIdsService::class.java)
     }
 
     override fun handle(command: DeleteTransactionsByIdsCommand): Result<TransactionDeletionResult> {
@@ -73,7 +73,7 @@ class DeleteTransactionsByIdsService(
                             year = transaction.date.year,
                             month = transaction.date.month
                         )
-                        logger.info("Marked month ${transaction.date.month}/${transaction.date.year} as excluded for regular transaction ${transaction.regularTransactionId}")
+                        log.info("Marked {}/{} as excluded for regular transaction: id={}", transaction.date.month, transaction.date.year, transaction.regularTransactionId)
                     }
                 }
 

--- a/domain/src/main/kotlin/fr/sacane/jmanager/domain/port/input/transaction/DeleteTransactionsByIdsUseCase.kt
+++ b/domain/src/main/kotlin/fr/sacane/jmanager/domain/port/input/transaction/DeleteTransactionsByIdsUseCase.kt
@@ -12,6 +12,8 @@ import fr.sacane.jmanager.domain.port.output.repository.TransactionRepository
 import fr.sacane.jmanager.domain.port.output.repository.UnitOfWorkTransactionProvider
 import fr.sacane.jmanager.domain.port.input.Command
 import fr.sacane.jmanager.domain.port.input.CommandHandler
+import fr.sacane.jmanager.domain.port.input.MdcContextProvider
+import fr.sacane.jmanager.domain.port.input.MdcKeys
 import fr.sacane.jmanager.domain.utils.*
 import java.util.UUID
 import org.slf4j.LoggerFactory
@@ -20,7 +22,9 @@ data class DeleteTransactionsByIdsCommand(
     val userId: UserId,
     val bookletID: UUID,
     val transactionIds: List<UUID>
-) : Command<TransactionDeletionResult>
+) : Command<TransactionDeletionResult>, MdcContextProvider {
+    override fun mdcContext() = mapOf(MdcKeys.BOOKLET_ID to bookletID.toString())
+}
 
 @Port(Side.APPLICATION)
 interface DeleteTransactionsByIdsUseCase : CommandHandler<DeleteTransactionsByIdsCommand, TransactionDeletionResult> {

--- a/domain/src/main/kotlin/fr/sacane/jmanager/domain/port/input/transaction/EditTransactionUseCase.kt
+++ b/domain/src/main/kotlin/fr/sacane/jmanager/domain/port/input/transaction/EditTransactionUseCase.kt
@@ -11,6 +11,8 @@ import fr.sacane.jmanager.domain.port.output.repository.TransactionRepository
 import fr.sacane.jmanager.domain.port.output.repository.UnitOfWorkTransactionProvider
 import fr.sacane.jmanager.domain.port.input.Command
 import fr.sacane.jmanager.domain.port.input.CommandHandler
+import fr.sacane.jmanager.domain.port.input.MdcContextProvider
+import fr.sacane.jmanager.domain.port.input.MdcKeys
 import fr.sacane.jmanager.domain.utils.*
 import java.time.LocalDateTime
 import java.util.UUID
@@ -19,7 +21,12 @@ data class EditTransactionCommand(
     val userId: UserId,
     val bookletID: UUID,
     val transaction: Transaction
-) : Command<TransactionResumeResult>
+) : Command<TransactionResumeResult>, MdcContextProvider {
+    override fun mdcContext() = buildMap {
+        put(MdcKeys.BOOKLET_ID, bookletID.toString())
+        transaction.id?.let { put(MdcKeys.TRANSACTION_ID, it.toString()) }
+    }
+}
 
 @Port(Side.APPLICATION)
 interface EditTransactionUseCase : CommandHandler<EditTransactionCommand, TransactionResumeResult> {

--- a/domain/src/main/kotlin/fr/sacane/jmanager/domain/port/input/transaction/ExcludeVirtualTransactionUseCase.kt
+++ b/domain/src/main/kotlin/fr/sacane/jmanager/domain/port/input/transaction/ExcludeVirtualTransactionUseCase.kt
@@ -7,6 +7,8 @@ import fr.sacane.jmanager.domain.models.UserId
 import fr.sacane.jmanager.domain.models.transaction.regular.RegularTransactionId
 import fr.sacane.jmanager.domain.port.input.Command
 import fr.sacane.jmanager.domain.port.input.CommandHandler
+import fr.sacane.jmanager.domain.port.input.MdcContextProvider
+import fr.sacane.jmanager.domain.port.input.MdcKeys
 import fr.sacane.jmanager.domain.port.output.repository.BookletRepository
 import fr.sacane.jmanager.domain.port.output.repository.RegularTransactionTrackerRepository
 import fr.sacane.jmanager.domain.utils.*
@@ -19,7 +21,9 @@ data class ExcludeVirtualTransactionCommand(
     val regularTransactionId: RegularTransactionId,
     val month: Month,
     val year: Int
-) : Command<Unit>
+) : Command<Unit>, MdcContextProvider {
+    override fun mdcContext() = mapOf(MdcKeys.BOOKLET_ID to bookletId.toString())
+}
 
 @Port(Side.APPLICATION)
 interface ExcludeVirtualTransactionUseCase : CommandHandler<ExcludeVirtualTransactionCommand, Unit> {

--- a/domain/src/main/kotlin/fr/sacane/jmanager/domain/port/input/transaction/FindTransactionByIdUseCase.kt
+++ b/domain/src/main/kotlin/fr/sacane/jmanager/domain/port/input/transaction/FindTransactionByIdUseCase.kt
@@ -6,16 +6,20 @@ import fr.sacane.jmanager.domain.hexadoc.Side
 import fr.sacane.jmanager.domain.models.UserId
 import fr.sacane.jmanager.domain.models.transaction.Transaction
 import fr.sacane.jmanager.domain.port.output.repository.TransactionRepository
+import fr.sacane.jmanager.domain.port.input.MdcContextProvider
+import fr.sacane.jmanager.domain.port.input.MdcKeys
 import fr.sacane.jmanager.domain.port.input.Query
 import fr.sacane.jmanager.domain.port.input.QueryHandler
 import fr.sacane.jmanager.domain.utils.*
 import java.util.UUID
-import java.util.logging.Logger
+import org.slf4j.LoggerFactory
 
 data class FindTransactionByIdQuery(
     val userId: UserId,
     val id: UUID
-) : Query<Transaction>
+) : Query<Transaction>, MdcContextProvider {
+    override fun mdcContext() = mapOf(MdcKeys.TRANSACTION_ID to id.toString())
+}
 
 @Port(Side.APPLICATION)
 interface FindTransactionByIdUseCase : QueryHandler<FindTransactionByIdQuery, Transaction> {
@@ -28,11 +32,10 @@ class FindTransactionByIdService(
 ) : FindTransactionByIdUseCase {
 
     companion object {
-        private val logger = Logger.getLogger(FindTransactionByIdService::class.java.name)
+        private val log = LoggerFactory.getLogger(FindTransactionByIdService::class.java)
     }
 
     override fun handle(query: FindTransactionByIdQuery): Result<Transaction> {
-        logger.info("Request for a transaction with id ${query.id}")
         val transaction = transactionRepository.findTransactionById(query.id)
             ?: return domainFailure(
                 ResultState.TRANSACTION_NOT_FOUND,

--- a/domain/src/main/kotlin/fr/sacane/jmanager/domain/port/input/user/LoginUseCase.kt
+++ b/domain/src/main/kotlin/fr/sacane/jmanager/domain/port/input/user/LoginUseCase.kt
@@ -15,7 +15,7 @@ import fr.sacane.jmanager.domain.utils.Result
 import fr.sacane.jmanager.domain.utils.ResultState
 import fr.sacane.jmanager.domain.utils.failure
 import fr.sacane.jmanager.domain.utils.success
-import java.util.logging.Logger
+import org.slf4j.LoggerFactory
 
 data class LoginCommand(val pseudonym: String, val userPassword: String) : Command<UserToken>
 
@@ -33,7 +33,7 @@ class LoginService(
 ) : LoginUseCase {
 
     companion object {
-        private val LOGGER = Logger.getLogger(LoginService::class.java.name)
+        private val log = LoggerFactory.getLogger(LoginService::class.java)
     }
 
     override fun handle(command: LoginCommand): Result<UserToken> {
@@ -42,10 +42,8 @@ class LoginService(
                 ResultState.NOT_FOUND,
                 DomainError(ResultState.NOT_FOUND.code, "domain.user.login.user_not_found", "L'utilisateur ${command.pseudonym} n'existe pas")
             )
-        LOGGER.info("LOGIN request for user ${userWithPassword.user.id}")
         val user = userWithPassword.user
         if (hasher.verify(command.userPassword, userWithPassword.password)) {
-            LOGGER.info("User ${userWithPassword.user.username} logged")
             val accessToken = tokenGenerator.generateToken(userWithPassword.user.id, userWithPassword.user.username, userWithPassword.roles)
             session.addSession(user.id, accessToken)
             accessToken.refreshToken?.let {
@@ -53,7 +51,7 @@ class LoginService(
             }
             return success(user.withToken(accessToken.tokenValue, accessToken.refreshToken))
         }
-        LOGGER.warning("Failed to log user ${command.pseudonym}")
+        log.warn("Authentication failed: invalid credentials for an existing account")
         return failure(
             ResultState.USER_UNAUTHORIZED,
             DomainError(ResultState.USER_UNAUTHORIZED.code, "domain.user.login.invalid_credentials", "Le pseudonyme ou le mot de passe est incorrect")

--- a/domain/src/main/kotlin/fr/sacane/jmanager/domain/port/input/user/RegisterUserUseCase.kt
+++ b/domain/src/main/kotlin/fr/sacane/jmanager/domain/port/input/user/RegisterUserUseCase.kt
@@ -15,6 +15,7 @@ import fr.sacane.jmanager.domain.utils.ResultState
 import fr.sacane.jmanager.domain.utils.DomainError
 import fr.sacane.jmanager.domain.utils.failure
 import fr.sacane.jmanager.domain.utils.success
+import org.slf4j.LoggerFactory
 
 data class RegisterUserCommand(
     val username: String,
@@ -34,6 +35,10 @@ class RegisterUserService(
     private val hasher: Hasher,
     private val notificationPort: NotificationPort,
 ) : RegisterUserUseCase {
+
+    companion object {
+        private val log = LoggerFactory.getLogger(RegisterUserService::class.java)
+    }
 
     override fun handle(command: RegisterUserCommand): Result<User> {
         if (command.password != command.confirmPassword) {
@@ -58,6 +63,7 @@ class RegisterUserService(
             DomainError(ResultState.INVALID.code, "domain.user.register.invalid", "Une erreur est survenue")
         )
         notificationPort.sendWelcomeEmail(userResult.username, command.email, userResult.subscriptionPlan)
+        log.info("User registered successfully: plan={}", userResult.subscriptionPlan)
         return success(userResult)
     }
 }


### PR DESCRIPTION
## Summary

- **Logback config** (`logback-spring.xml`) : appenders rotatifs async pour la prod (app.log 1.5 GB/30j + error.log 300 MB/90j, archives `.gz`) et console colorée en local/test
- **Bus decorators** : `LoggingCommandBus` + `LoggingQueryBus` (`@Primary`) — trace chaque dispatch avec le nom de la commande/query, le `ResultState`, et la durée en ms
- **Migration JUL → SLF4J** dans tous les use cases du domaine ; `slf4j-api` ajouté à `domain/build.gradle.kts`
- **Suppression** des logs redondants, coûteux ou contenant des PII (username, toString() sur Transaction/Booklet entiers)
- **Ajout** des logs pertinents manquants : auth failure sans PII, suppression de livret, inscription utilisateur, force-replace de tag, bilan import CSV avec stack trace complète

## Détail des changements

### application layer
| Fichier | Changement |
|---|---|
| `logback-spring.xml` | Nouveau — config complète prod/local/test |
| `LoggingCommandBus` | Nouveau — décorateur `@Primary` sur `CommandBus` |
| `LoggingQueryBus` | Nouveau — décorateur `@Primary` sur `QueryBus` |
| `CommandBus` / `QueryBus` | JUL → SLF4J, syntaxe `{}` |

### domain layer
| Fichier | Changement |
|---|---|
| `build.gradle.kts` | Ajout `slf4j-api:2.0.16` |
| `LoginUseCase` | ❌ Suppression logs PII (username/id) · ✅ WARN auth failure sans PII |
| `BookTransactionUseCase` | ❌ Suppression log inutile (userId) + log coûteux (toString objets) · ✅ INFO id UUID |
| `DeleteTransactionsByIdsUseCase` | JUL → SLF4J, paramètres `{}` |
| `ImportTransactionsFromCsvUseCase` | JUL → SLF4J · `severe` → `log.error(..., e)` avec stack trace |
| `RegisterUserUseCase` | ➕ INFO registration + plan |
| `DeleteBookletByIdUseCase` | ➕ INFO suppression irréversible |
| `DeleteTagUseCase` | ➕ WARN force-replace mutation de masse |

## Test plan

- [ ] Lancer en profil `local` → logs colorés en console, SQL visible, aucun fichier créé
- [ ] Lancer en profil `prod` → `app.log` et `error.log` créés dans `/var/log/jmanager/`
- [ ] Exécuter une commande → une ligne `COMMAND | ... | OK | X ms` visible dans `app.log`
- [ ] Exécuter une query → une ligne `QUERY | ... | OK | X ms` visible dans `app.log`
- [ ] Tenter un login avec mauvais mot de passe → `WARN Authentication failed` sans pseudonyme dans `app.log`
- [ ] Supprimer un livret → `INFO Booklet deleted: id=...` dans `app.log`
- [ ] Importer un CSV invalide → stack trace complète dans `error.log`

🤖 Generated with [Claude Code](https://claude.com/claude-code)