### PR TITLE
fix(logging): fix %clr startup crash and missing Docker logs

### DIFF
--- a/application/src/main/resources/logback-spring.xml
+++ b/application/src/main/resources/logback-spring.xml
@@ -1,6 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration scan="true" scanPeriod="60 seconds">
 
+  <!-- Convertisseurs Spring Boot requis dans un logback-spring.xml custom -->
+  <conversionRule conversionWord="clr" converterClass="org.springframework.boot.logging.logback.ColorConverter"/>
+  <conversionRule conversionWord="wex" converterClass="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter"/>
+  <conversionRule conversionWord="wEx" converterClass="org.springframework.boot.logging.logback.ExtendedWhitespaceThrowableProxyConverter"/>
+
   <springProfile name="local,test">
 
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
@@ -125,13 +130,25 @@
     </appender>
 
     <!-- ─────────────────────────────────────────
+         Appender console — stdout pour docker logs
+         Pas d'AsyncAppender : le daemon Docker bufferise stdout nativement
+         ───────────────────────────────────────── -->
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+      <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+        <charset>UTF-8</charset>
+        <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level [%thread] %logger{36}%replace( [booklet=%X{bookletId}]){' \[booklet=\]', ''}%replace( [tx=%X{transactionId}]){' \[tx=\]', ''} - %msg%n</pattern>
+      </encoder>
+    </appender>
+
+    <!-- ─────────────────────────────────────────
          Niveaux par package
          ───────────────────────────────────────── -->
 
-    <!-- Code JManager : INFO — les deux fichiers -->
+    <!-- Code JManager : INFO — fichiers + console -->
     <logger name="fr.sacane.jmanager" level="INFO" additivity="false">
       <appender-ref ref="ASYNC_APP"/>
       <appender-ref ref="ASYNC_ERROR"/>
+      <appender-ref ref="CONSOLE"/>
     </logger>
 
     <!-- Flyway : INFO pour tracer les migrations en prod -->
@@ -149,10 +166,11 @@
     <logger name="org.apache.catalina"                       level="WARN"/>
     <logger name="org.apache.coyote"                         level="WARN"/>
 
-    <!-- Root catch-all : WARN -->
+    <!-- Root catch-all : WARN — fichiers + console -->
     <root level="WARN">
       <appender-ref ref="ASYNC_APP"/>
       <appender-ref ref="ASYNC_ERROR"/>
+      <appender-ref ref="CONSOLE"/>
     </root>
 
   </springProfile>


### PR DESCRIPTION
## Summary

- **Bug 1 — Crash au démarrage (local/test)** : `%clr` est un convertisseur custom Spring Boot qui n'est pas auto-enregistré quand on fournit un `logback-spring.xml` complet. Ajout des trois `<conversionRule>` manquantes en tête de fichier (`clr`, `wex`, `wEx`).
- **Bug 2 — Aucun log visible dans Docker** : le profil `prod` n'avait pas de `ConsoleAppender` — `docker logs` ne capture que stdout/stderr. Ajout d'un `ConsoleAppender` (sans async, le daemon Docker bufferise nativement) câblé sur `fr.sacane.jmanager` (INFO+) et `root` (WARN+). Les fichiers `app.log` / `error.log` restent inchangés.

## Test plan

- [ ] Lancer l'app en local (`spring.profiles.active=local`) → démarrage sans `IllegalStateException`, logs colorés visibles en console
- [ ] Lancer l'app en prod via Docker Compose → `docker logs <container>` affiche les logs INFO+ du code métier et WARN+ des libs
- [ ] Vérifier que `app.log` et `error.log` continuent d'être écrits sur le volume monté

🤖 Generated with [Claude Code](https://claude.com/claude-code)