### PR TITLE
feat(ops): add Spring Boot Actuator health endpoint

### DIFF
--- a/application/build.gradle.kts
+++ b/application/build.gradle.kts
@@ -19,6 +19,7 @@ dependencies {
     implementation(project(":infrastructure"))
 
     implementation("org.springframework.boot:spring-boot-starter-web:${springBootVersion}")
+    implementation("org.springframework.boot:spring-boot-starter-actuator:${springBootVersion}")
     implementation("org.springframework.boot:spring-boot-starter-validation:${springBootVersion}")
     implementation("org.springframework.boot:spring-boot-starter-security:${springBootVersion}")
     implementation("org.springframework.boot:spring-boot-starter-cache:${springBootVersion}")

--- a/application/src/main/kotlin/fr/sacane/jmanager/application/api/SecurityConfig.kt
+++ b/application/src/main/kotlin/fr/sacane/jmanager/application/api/SecurityConfig.kt
@@ -54,6 +54,8 @@ class SecurityConfig(
                 authorize("/privacy", permitAll)
                 authorize("/terms", permitAll)
                 authorize("/consent", permitAll)
+                // Actuator
+                authorize("/actuator/health", permitAll)
                 // Public API
                 authorize("/api/user/create", permitAll)
                 authorize("/api/user/auth", permitAll)

--- a/application/src/main/resources/application.properties
+++ b/application/src/main/resources/application.properties
@@ -20,6 +20,10 @@ server.tomcat.max-http-post-size=2097152
 # Application URL (used in emails)
 app.url=${APP_URL:http://localhost:3000}
 
+# Actuator — health endpoint only
+management.endpoints.web.exposure.include=health
+management.endpoint.health.show-details=never
+
 # Data retention (GDPR Art. 5(1)(e))
 jmanager.retention.unconsented-account-days=30
 jmanager.retention.cron=0 0 2 * * *


### PR DESCRIPTION
## Summary

- Adds `spring-boot-starter-actuator` to the `application` module
- Exposes only `/actuator/health` via `management.endpoints.web.exposure.include=health`
- Sets `management.endpoint.health.show-details=never` to avoid leaking DB/disk state publicly
- Permits `/actuator/health` in `SecurityConfig` (placed before the `anyRequest, denyAll` catch-all)

## Motivation

The `/actuator/health` endpoint is useful in production for reverse proxy liveness/readiness checks (nginx, Caddy, etc.) without introducing any meaningful CPU or RAM overhead (~5–10 MB).

All other actuator endpoints remain disabled — only `health` is exposed.

## Reviewer notes

- No other endpoints are reachable — confirmed by `management.endpoints.web.exposure.include=health`
- `show-details=never` means the response body is simply `{"status":"UP"}` — nothing sensitive exposed
- If horizontal scaling is ever needed, a separate management port (`management.server.port`) can be added at that point

🤖 Generated with [Claude Code](https://claude.com/claude-code)