### PR TITLE
refactor(feature-flag): consolidate FeatureKey enum and add orphan cl…

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,6 +54,9 @@ jobs:
       - name: Allow execution permission
         run: chmod +x ./gradlew
 
+      - name: Clean domain module to prevent stale compiled classes
+        run: ./gradlew :domain:clean
+
       - name: Run tests
         run: ./gradlew :domain:test :infrastructure:test :application:test jacocoTestReport --info --stacktrace
 

--- a/application/src/test/kotlin/fr/sacane/jmanager/application/api/FeatureFlagControllerTest.kt
+++ b/application/src/test/kotlin/fr/sacane/jmanager/application/api/FeatureFlagControllerTest.kt
@@ -5,19 +5,20 @@ import fr.sacane.jmanager.domain.port.input.user.CreateAdminIfNotExistsCommand
 import fr.sacane.jmanager.domain.port.input.user.CreateAdminIfNotExistsUseCase
 import fr.sacane.jmanager.domain.port.input.user.LoginCommand
 import fr.sacane.jmanager.domain.port.input.user.LoginUseCase
+import fr.sacane.jmanager.infrastructure.spi.entity.FeatureFlagEntity
 import fr.sacane.jmanager.infrastructure.spi.repositories.FeatureFlagJpaRepository
 import io.restassured.module.kotlin.extensions.Given
 import io.restassured.module.kotlin.extensions.Then
 import io.restassured.module.kotlin.extensions.When
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.CoreMatchers.notNullValue
-import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.web.server.LocalServerPort
+import org.springframework.cache.CacheManager
 import org.springframework.test.context.TestPropertySource
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
@@ -25,6 +26,7 @@ import org.springframework.test.context.TestPropertySource
 class FeatureFlagControllerTest(
     @LocalServerPort private val port: Int,
     @Autowired private val featureFlagJpaRepository: FeatureFlagJpaRepository,
+    @Autowired private val cacheManager: CacheManager,
     @Autowired private val createAdminIfNotExistsUseCase: CreateAdminIfNotExistsUseCase,
     @Autowired private val loginUseCase: LoginUseCase,
 ) : AuthenticatedUserTest() {
@@ -32,16 +34,20 @@ class FeatureFlagControllerTest(
     private lateinit var adminToken: String
 
     @BeforeEach
+    fun setupFlags() {
+        featureFlagJpaRepository.deleteAll()
+        cacheManager.getCache("featureFlags")?.clear()
+        FeatureKey.entries.forEach { key ->
+            featureFlagJpaRepository.save(FeatureFlagEntity(key = key.name, enabled = false))
+        }
+    }
+
+    @BeforeEach
     fun setupAdmin() {
         createAdminIfNotExistsUseCase.handle(CreateAdminIfNotExistsCommand("admin-flag", "admin123"))
         loginUseCase.handle(LoginCommand("admin-flag", "admin123")).onSuccess {
             adminToken = it.token
         }
-    }
-
-    @AfterEach
-    fun clearFlags() {
-        featureFlagJpaRepository.deleteAll()
     }
 
     @Nested

--- a/application/src/test/kotlin/fr/sacane/jmanager/application/api/FeatureFlagControllerTest.kt
+++ b/application/src/test/kotlin/fr/sacane/jmanager/application/api/FeatureFlagControllerTest.kt
@@ -33,6 +33,9 @@ class FeatureFlagControllerTest(
 
     private lateinit var adminToken: String
 
+    /** First available key at runtime — avoids coupling to a specific enum constant. */
+    private val anyKey get() = FeatureKey.entries.first().name
+
     @BeforeEach
     fun setupFlags() {
         featureFlagJpaRepository.deleteAll()
@@ -97,7 +100,7 @@ class FeatureFlagControllerTest(
                 get("/api/feature-flags")
             } Then {
                 statusCode(200)
-                body("find { it.key == 'EMAIL_VERIFICATION' }.enabled", equalTo(false))
+                body("find { it.key == '$anyKey' }.enabled", equalTo(false))
             }
         }
     }
@@ -113,10 +116,10 @@ class FeatureFlagControllerTest(
                 header("Content-Type", "application/json")
                 body("""{"enabled": true}""")
             } When {
-                patch("/api/admin/feature-flags/EMAIL_VERIFICATION")
+                patch("/api/admin/feature-flags/$anyKey")
             } Then {
                 statusCode(200)
-                body("key", equalTo("EMAIL_VERIFICATION"))
+                body("key", equalTo(anyKey))
                 body("enabled", equalTo(true))
             }
         }
@@ -129,7 +132,7 @@ class FeatureFlagControllerTest(
                 header("Content-Type", "application/json")
                 body("""{"enabled": true}""")
             } When {
-                patch("/api/admin/feature-flags/EMAIL_VERIFICATION")
+                patch("/api/admin/feature-flags/$anyKey")
             } Then {
                 statusCode(200)
             }
@@ -140,7 +143,7 @@ class FeatureFlagControllerTest(
                 get("/api/feature-flags")
             } Then {
                 statusCode(200)
-                body("find { it.key == 'EMAIL_VERIFICATION' }.enabled", equalTo(true))
+                body("find { it.key == '$anyKey' }.enabled", equalTo(true))
             }
         }
 
@@ -152,7 +155,7 @@ class FeatureFlagControllerTest(
                 header("Content-Type", "application/json")
                 body("""{"enabled": true}""")
             } When {
-                patch("/api/admin/feature-flags/EMAIL_VERIFICATION")
+                patch("/api/admin/feature-flags/$anyKey")
             } Then {
                 statusCode(403)
             }
@@ -165,7 +168,7 @@ class FeatureFlagControllerTest(
                 header("Content-Type", "application/json")
                 body("""{"enabled": true}""")
             } When {
-                patch("/api/admin/feature-flags/EMAIL_VERIFICATION")
+                patch("/api/admin/feature-flags/$anyKey")
             } Then {
                 statusCode(401)
             }
@@ -193,7 +196,7 @@ class FeatureFlagControllerTest(
                 header("Content-Type", "application/json")
                 body("""{"enabled": true}""")
             } When {
-                patch("/api/admin/feature-flags/EMAIL_VERIFICATION")
+                patch("/api/admin/feature-flags/$anyKey")
             }
 
             Given {
@@ -202,7 +205,7 @@ class FeatureFlagControllerTest(
                 header("Content-Type", "application/json")
                 body("""{"enabled": false}""")
             } When {
-                patch("/api/admin/feature-flags/EMAIL_VERIFICATION")
+                patch("/api/admin/feature-flags/$anyKey")
             } Then {
                 statusCode(200)
                 body("enabled", equalTo(false))

--- a/domain/src/main/kotlin/fr/sacane/jmanager/domain/models/FeatureFlag.kt
+++ b/domain/src/main/kotlin/fr/sacane/jmanager/domain/models/FeatureFlag.kt
@@ -1,8 +1,7 @@
 package fr.sacane.jmanager.domain.models
 
 enum class FeatureKey {
-    EMAIL_VERIFICATION,
-    EMAIL_VERIFICATION_SIMPLE_USER_REGISTRATION,
+    USER_REGISTRATION
 }
 
 data class FeatureFlag(

--- a/domain/src/test/kotlin/fr/sacane/jmanager/domain/port/FeatureFlagFeatureTest.kt
+++ b/domain/src/test/kotlin/fr/sacane/jmanager/domain/port/FeatureFlagFeatureTest.kt
@@ -38,25 +38,25 @@ class FeatureFlagFeatureTest {
 
         @Test
         fun `unpersisted flag defaults to disabled`() {
-            val result = act { isFeatureEnabledUseCase.handle(IsFeatureEnabledQuery(FeatureKey.EMAIL_VERIFICATION)) }
+            val result = act { isFeatureEnabledUseCase.handle(IsFeatureEnabledQuery(FeatureKey.USER_REGISTRATION)) }
 
             then(result) { assertTrue { this == false } }
         }
 
         @Test
         fun `enabled flag returns true`() {
-            repository.upsert(FeatureFlag(FeatureKey.EMAIL_VERIFICATION, enabled = true))
+            repository.upsert(FeatureFlag(FeatureKey.USER_REGISTRATION, enabled = true))
 
-            val result = act { isFeatureEnabledUseCase.handle(IsFeatureEnabledQuery(FeatureKey.EMAIL_VERIFICATION)) }
+            val result = act { isFeatureEnabledUseCase.handle(IsFeatureEnabledQuery(FeatureKey.USER_REGISTRATION)) }
 
             then(result) { assertTrue { this == true } }
         }
 
         @Test
         fun `explicitly disabled flag returns false`() {
-            repository.upsert(FeatureFlag(FeatureKey.EMAIL_VERIFICATION, enabled = false))
+            repository.upsert(FeatureFlag(FeatureKey.USER_REGISTRATION, enabled = false))
 
-            val result = act { isFeatureEnabledUseCase.handle(IsFeatureEnabledQuery(FeatureKey.EMAIL_VERIFICATION)) }
+            val result = act { isFeatureEnabledUseCase.handle(IsFeatureEnabledQuery(FeatureKey.USER_REGISTRATION)) }
 
             then(result) { assertTrue { this == false } }
         }
@@ -88,28 +88,14 @@ class FeatureFlagFeatureTest {
 
         @Test
         fun `persisted enabled flag is reflected in the list`() {
-            repository.upsert(FeatureFlag(FeatureKey.EMAIL_VERIFICATION, enabled = true))
+            repository.upsert(FeatureFlag(FeatureKey.USER_REGISTRATION, enabled = true))
 
             val result = act { getAllFeatureFlagsUseCase.handle(GetAllFeatureFlagsQuery()) }
 
             then(result) {
                 assertSuccess()
-                val emailVerification = mapNotNullOrFailure()!!.first { it.key == FeatureKey.EMAIL_VERIFICATION }
-                assertTrue { emailVerification.enabled }
-            }
-        }
-
-        @Test
-        fun `keys not yet persisted appear as disabled alongside persisted ones`() {
-            repository.upsert(FeatureFlag(FeatureKey.EMAIL_VERIFICATION, enabled = true))
-
-            val result = act { getAllFeatureFlagsUseCase.handle(GetAllFeatureFlagsQuery()) }
-
-            then(result) {
-                assertSuccess()
-                val subFlag = mapNotNullOrFailure()!!
-                    .first { it.key == FeatureKey.EMAIL_VERIFICATION_SIMPLE_USER_REGISTRATION }
-                assertTrue { !subFlag.enabled }
+                val userRegistration = mapNotNullOrFailure()!!.first { it.key == FeatureKey.USER_REGISTRATION }
+                assertTrue { userRegistration.enabled }
             }
         }
     }
@@ -120,7 +106,7 @@ class FeatureFlagFeatureTest {
         @Test
         fun `toggling a flag to enabled persists the change`() {
             val result = act {
-                toggleFeatureFlagUseCase.handle(ToggleFeatureFlagCommand(FeatureKey.EMAIL_VERIFICATION, enabled = true))
+                toggleFeatureFlagUseCase.handle(ToggleFeatureFlagCommand(FeatureKey.USER_REGISTRATION, enabled = true))
             }
 
             then(result) {
@@ -131,10 +117,10 @@ class FeatureFlagFeatureTest {
 
         @Test
         fun `toggling an enabled flag to disabled persists the change`() {
-            repository.upsert(FeatureFlag(FeatureKey.EMAIL_VERIFICATION, enabled = true))
+            repository.upsert(FeatureFlag(FeatureKey.USER_REGISTRATION, enabled = true))
 
             val result = act {
-                toggleFeatureFlagUseCase.handle(ToggleFeatureFlagCommand(FeatureKey.EMAIL_VERIFICATION, enabled = false))
+                toggleFeatureFlagUseCase.handle(ToggleFeatureFlagCommand(FeatureKey.USER_REGISTRATION, enabled = false))
             }
 
             then(result) {
@@ -146,20 +132,20 @@ class FeatureFlagFeatureTest {
         @Test
         fun `isEnabled reflects state after toggle`() {
             act {
-                toggleFeatureFlagUseCase.handle(ToggleFeatureFlagCommand(FeatureKey.EMAIL_VERIFICATION, enabled = true))
+                toggleFeatureFlagUseCase.handle(ToggleFeatureFlagCommand(FeatureKey.USER_REGISTRATION, enabled = true))
             }
 
-            val result = act { isFeatureEnabledUseCase.handle(IsFeatureEnabledQuery(FeatureKey.EMAIL_VERIFICATION)) }
+            val result = act { isFeatureEnabledUseCase.handle(IsFeatureEnabledQuery(FeatureKey.USER_REGISTRATION)) }
 
             then(result) { assertTrue { this == true } }
         }
 
         @Test
         fun `toggling is idempotent — enabling an already enabled flag succeeds`() {
-            repository.upsert(FeatureFlag(FeatureKey.EMAIL_VERIFICATION, enabled = true))
+            repository.upsert(FeatureFlag(FeatureKey.USER_REGISTRATION, enabled = true))
 
             val result = act {
-                toggleFeatureFlagUseCase.handle(ToggleFeatureFlagCommand(FeatureKey.EMAIL_VERIFICATION, enabled = true))
+                toggleFeatureFlagUseCase.handle(ToggleFeatureFlagCommand(FeatureKey.USER_REGISTRATION, enabled = true))
             }
 
             then(result) {

--- a/infrastructure/src/main/kotlin/fr/sacane/jmanager/infrastructure/spi/configuration/FeatureFlagSeeder.kt
+++ b/infrastructure/src/main/kotlin/fr/sacane/jmanager/infrastructure/spi/configuration/FeatureFlagSeeder.kt
@@ -9,9 +9,11 @@ import org.springframework.context.event.ContextRefreshedEvent
 import org.springframework.stereotype.Component
 
 /**
- * Ensures every known [FeatureKey] has a row in the `feature_flag` table after each deploy.
- * Newly added keys are inserted as **disabled** (safe-by-default).
- * Existing rows — including those toggled ON by an administrator — are never overwritten.
+ * Synchronises the `feature_flag` table with the known [FeatureKey] enum on every deploy.
+ *
+ * - Keys present in the enum but absent from the DB are inserted as **disabled** (safe-by-default).
+ * - Keys present in the DB but removed from the enum are **deleted** (orphan cleanup).
+ * - Existing rows whose key is still in the enum are never touched, preserving admin-configured values.
  */
 @Component
 class FeatureFlagSeeder(
@@ -28,13 +30,22 @@ class FeatureFlagSeeder(
     }
 
     internal fun seed() {
-        var inserted = 0
-        FeatureKey.entries.forEach { key ->
-            if (!jpaRepository.existsById(key.name)) {
-                jpaRepository.save(FeatureFlagEntity(key = key.name, enabled = false))
-                inserted++
-            }
+        val knownKeys = FeatureKey.entries.map { it.name }.toSet()
+        val existingKeys = jpaRepository.findAll().map { it.key }.toSet()
+
+        val toDelete = existingKeys - knownKeys
+        val toInsert = knownKeys - existingKeys
+
+        if (toDelete.isNotEmpty()) {
+            jpaRepository.deleteAllById(toDelete)
         }
-        log.info("Feature flag seeding complete: $inserted new flag(s) inserted (${FeatureKey.entries.size} total known)")
+        toInsert.forEach { key ->
+            jpaRepository.save(FeatureFlagEntity(key = key, enabled = false))
+        }
+
+        log.info(
+            "Feature flag seeding complete: ${toInsert.size} inserted, ${toDelete.size} removed" +
+                " (${knownKeys.size} total known)"
+        )
     }
 }

--- a/infrastructure/src/test/kotlin/fr/sacane/jmanager/infrastructure/spi/adapters/FeatureFlagRepositoryJpaAdapterIT.kt
+++ b/infrastructure/src/test/kotlin/fr/sacane/jmanager/infrastructure/spi/adapters/FeatureFlagRepositoryJpaAdapterIT.kt
@@ -29,55 +29,55 @@ class FeatureFlagRepositoryJpaAdapterIT(
 
     @Test
     fun `findByKey returns null for a flag that has never been persisted`() {
-        val result = adapter.findByKey(FeatureKey.EMAIL_VERIFICATION)
+        val result = adapter.findByKey(FeatureKey.USER_REGISTRATION)
 
         assertThat(result).isNull()
     }
 
     @Test
     fun `findByKey returns the flag with its persisted enabled state`() {
-        jpaRepository.save(FeatureFlagEntity(key = FeatureKey.EMAIL_VERIFICATION.name, enabled = true))
+        jpaRepository.save(FeatureFlagEntity(key = FeatureKey.USER_REGISTRATION.name, enabled = true))
 
-        val result = adapter.findByKey(FeatureKey.EMAIL_VERIFICATION)
+        val result = adapter.findByKey(FeatureKey.USER_REGISTRATION)
 
-        assertThat(result).isEqualTo(FeatureFlag(FeatureKey.EMAIL_VERIFICATION, enabled = true))
+        assertThat(result).isEqualTo(FeatureFlag(FeatureKey.USER_REGISTRATION, enabled = true))
     }
 
     @Test
     fun `findByKey returns disabled flag when persisted as disabled`() {
-        jpaRepository.save(FeatureFlagEntity(key = FeatureKey.EMAIL_VERIFICATION.name, enabled = false))
+        jpaRepository.save(FeatureFlagEntity(key = FeatureKey.USER_REGISTRATION.name, enabled = false))
 
-        val result = adapter.findByKey(FeatureKey.EMAIL_VERIFICATION)
+        val result = adapter.findByKey(FeatureKey.USER_REGISTRATION)
 
-        assertThat(result).isEqualTo(FeatureFlag(FeatureKey.EMAIL_VERIFICATION, enabled = false))
+        assertThat(result).isEqualTo(FeatureFlag(FeatureKey.USER_REGISTRATION, enabled = false))
     }
 
     // ── Adapter: upsert ────────────────────────────────────────────────────
 
     @Test
     fun `upsert inserts a new flag and returns it`() {
-        val flag = FeatureFlag(FeatureKey.EMAIL_VERIFICATION, enabled = true)
+        val flag = FeatureFlag(FeatureKey.USER_REGISTRATION, enabled = true)
 
         val result = adapter.upsert(flag)
 
         assertThat(result).isEqualTo(flag)
-        assertThat(jpaRepository.findById(FeatureKey.EMAIL_VERIFICATION.name).get().enabled).isTrue()
+        assertThat(jpaRepository.findById(FeatureKey.USER_REGISTRATION.name).get().enabled).isTrue()
     }
 
     @Test
     fun `upsert updates an existing flag without creating a duplicate`() {
-        jpaRepository.save(FeatureFlagEntity(key = FeatureKey.EMAIL_VERIFICATION.name, enabled = false))
+        jpaRepository.save(FeatureFlagEntity(key = FeatureKey.USER_REGISTRATION.name, enabled = false))
 
-        adapter.upsert(FeatureFlag(FeatureKey.EMAIL_VERIFICATION, enabled = true))
+        adapter.upsert(FeatureFlag(FeatureKey.USER_REGISTRATION, enabled = true))
 
-        val all = jpaRepository.findAll().filter { it.key == FeatureKey.EMAIL_VERIFICATION.name }
+        val all = jpaRepository.findAll().filter { it.key == FeatureKey.USER_REGISTRATION.name }
         assertThat(all).hasSize(1)
         assertThat(all.first().enabled).isTrue()
     }
 
     @Test
     fun `upsert is idempotent when called twice with the same state`() {
-        val flag = FeatureFlag(FeatureKey.EMAIL_VERIFICATION, enabled = true)
+        val flag = FeatureFlag(FeatureKey.USER_REGISTRATION, enabled = true)
 
         adapter.upsert(flag)
         val result = adapter.upsert(flag)
@@ -97,16 +97,12 @@ class FeatureFlagRepositoryJpaAdapterIT(
 
     @Test
     fun `findAll returns all persisted flags`() {
-        jpaRepository.save(FeatureFlagEntity(key = FeatureKey.EMAIL_VERIFICATION.name, enabled = true))
-        jpaRepository.save(FeatureFlagEntity(key = FeatureKey.EMAIL_VERIFICATION_SIMPLE_USER_REGISTRATION.name, enabled = false))
+        jpaRepository.save(FeatureFlagEntity(key = FeatureKey.USER_REGISTRATION.name, enabled = true))
 
         val result = adapter.findAll()
 
-        assertThat(result).hasSize(2)
-        assertThat(result.map { it.key }).containsExactlyInAnyOrder(
-            FeatureKey.EMAIL_VERIFICATION,
-            FeatureKey.EMAIL_VERIFICATION_SIMPLE_USER_REGISTRATION,
-        )
+        assertThat(result).hasSize(1)
+        assertThat(result.map { it.key }).containsExactly(FeatureKey.USER_REGISTRATION)
     }
 
     // ── Seeder ─────────────────────────────────────────────────────────────
@@ -125,11 +121,11 @@ class FeatureFlagRepositoryJpaAdapterIT(
 
         @Test
         fun `seeder does not overwrite an admin-enabled flag`() {
-            jpaRepository.save(FeatureFlagEntity(key = FeatureKey.EMAIL_VERIFICATION.name, enabled = true))
+            jpaRepository.save(FeatureFlagEntity(key = FeatureKey.USER_REGISTRATION.name, enabled = true))
 
             seeder.seed()
 
-            val flag = jpaRepository.findById(FeatureKey.EMAIL_VERIFICATION.name).get()
+            val flag = jpaRepository.findById(FeatureKey.USER_REGISTRATION.name).get()
             assertThat(flag.enabled).isTrue()
         }
 
@@ -138,6 +134,16 @@ class FeatureFlagRepositoryJpaAdapterIT(
             seeder.seed()
             seeder.seed()
 
+            assertThat(jpaRepository.count()).isEqualTo(FeatureKey.entries.size.toLong())
+        }
+
+        @Test
+        fun `seeder removes orphaned flags that are no longer in the enum`() {
+            jpaRepository.save(FeatureFlagEntity(key = "OBSOLETE_FLAG", enabled = true))
+
+            seeder.seed()
+
+            assertThat(jpaRepository.existsById("OBSOLETE_FLAG")).isFalse()
             assertThat(jpaRepository.count()).isEqualTo(FeatureKey.entries.size.toLong())
         }
     }


### PR DESCRIPTION
…eanup to seeder

- Replace EMAIL_VERIFICATION and EMAIL_VERIFICATION_SIMPLE_USER_REGISTRATION with a single USER_REGISTRATION key
- Seeder now deletes DB rows whose key no longer exists in the enum (orphan cleanup), preserving admin-configured values for still-known keys
- Update all domain and infrastructure tests to reflect the new enum and seeder behaviour