### PR TITLE
feat(version): display app version in sidebar footer

### DIFF
--- a/application/build.gradle.kts
+++ b/application/build.gradle.kts
@@ -49,6 +49,10 @@ tasks.test {
     systemProperty("testcontainers.reuse.enable", "true")
 }
 
+springBoot {
+    buildInfo()
+}
+
 tasks {
     shadowJar {
         mergeServiceFiles()

--- a/application/src/main/kotlin/fr/sacane/jmanager/application/api/SecurityConfig.kt
+++ b/application/src/main/kotlin/fr/sacane/jmanager/application/api/SecurityConfig.kt
@@ -56,6 +56,7 @@ class SecurityConfig(
                 authorize("/consent", permitAll)
                 // Actuator
                 authorize("/actuator/health", permitAll)
+                authorize("/actuator/info", permitAll)
                 // Public API
                 authorize("/api/feature-flags", permitAll)
                 authorize("/api/user/create", permitAll)

--- a/application/src/main/resources/application.properties
+++ b/application/src/main/resources/application.properties
@@ -20,9 +20,10 @@ server.tomcat.max-http-post-size=2097152
 # Application URL (used in emails)
 app.url=${APP_URL:http://localhost:3000}
 
-# Actuator — health endpoint only
-management.endpoints.web.exposure.include=health
+# Actuator
+management.endpoints.web.exposure.include=health,info
 management.endpoint.health.show-details=never
+management.info.build.enabled=true
 
 # Data retention (GDPR Art. 5(1)(e))
 jmanager.retention.unconsented-account-days=30

--- a/application/src/test/kotlin/fr/sacane/jmanager/application/api/ActuatorInfoTest.kt
+++ b/application/src/test/kotlin/fr/sacane/jmanager/application/api/ActuatorInfoTest.kt
@@ -1,0 +1,38 @@
+package fr.sacane.jmanager.application.api
+
+import fr.sacane.jmanager.application.AbstractIntegrationTest
+import io.restassured.module.kotlin.extensions.Given
+import io.restassured.module.kotlin.extensions.Then
+import io.restassured.module.kotlin.extensions.When
+import org.hamcrest.CoreMatchers.notNullValue
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.web.server.LocalServerPort
+
+class ActuatorInfoTest : AbstractIntegrationTest() {
+
+    @LocalServerPort
+    private val port: Int = 0
+
+    @Test
+    fun `GET actuator-info without authentication returns 200`() {
+        Given {
+            port(port)
+        } When {
+            get("/actuator/info")
+        } Then {
+            statusCode(200)
+        }
+    }
+
+    @Test
+    fun `GET actuator-info returns build version`() {
+        Given {
+            port(port)
+        } When {
+            get("/actuator/info")
+        } Then {
+            statusCode(200)
+            body("build.version", notNullValue())
+        }
+    }
+}

--- a/client/components/app-sidebar.vue
+++ b/client/components/app-sidebar.vue
@@ -5,6 +5,7 @@ import useAuth from '../composables/useAuth'
 import 'primeicons/primeicons.css'
 
 const { isAuthenticated, isAdmin } = useAuth()
+const { version, fetchVersion } = useAppVersion()
 const isSidebarOpen = ref(false)
 const isMobileView = ref(false)
 
@@ -37,6 +38,7 @@ function handleClickOutside(event: MouseEvent) {
 
 onMounted(() => {
   checkMobile()
+  fetchVersion()
   window.addEventListener('resize', checkMobile)
   document.addEventListener('click', handleClickOutside)
 })
@@ -151,6 +153,7 @@ onUnmounted(() => {
 
         <div class="sidebar-footer">
           <Profile />
+          <span v-if="version" class="app-version">{{ `v${version}` }}</span>
         </div>
       </div>
     </aside>
@@ -556,6 +559,16 @@ onUnmounted(() => {
     border-top-color: rgba(101, 8, 204, 0.2);
     background: rgba(101, 8, 204, 0.04);
   }
+}
+
+.app-version {
+  display: block;
+  margin-top: 0.5rem;
+  font-size: 0.7rem;
+  font-family: monospace;
+  color: rgba(255, 255, 255, 0.3);
+  letter-spacing: 0.03em;
+  user-select: none;
 }
 
 @media (min-width: 769px) {

--- a/client/composables/useAppVersion.ts
+++ b/client/composables/useAppVersion.ts
@@ -1,0 +1,18 @@
+import axios from 'axios'
+
+export default function useAppVersion() {
+  const version = useState<string | null>('app:version', () => null)
+
+  async function fetchVersion(): Promise<void> {
+    try {
+      const config = useRuntimeConfig()
+      const origin = new URL(config.public.apiUrl).origin
+      const response = await axios.get(`${origin}/actuator/info`)
+      version.value = response.data?.build?.version ?? null
+    } catch {
+      version.value = null
+    }
+  }
+
+  return { version: readonly(version), fetchVersion }
+}

--- a/client/tests/setup.ts
+++ b/client/tests/setup.ts
@@ -118,6 +118,11 @@ vi.stubGlobal('useAdmin', vi.fn(() => ({
   fetchUsers: vi.fn(),
 })))
 
+vi.stubGlobal('useAppVersion', vi.fn(() => ({
+  version: ref(null),
+  fetchVersion: vi.fn(),
+})))
+
 vi.stubGlobal('useFeatureFlags', vi.fn(() => ({
   flags: readonly(ref([])),
   isFetching: ref(false),

--- a/client/tests/unit/useAppVersion.spec.ts
+++ b/client/tests/unit/useAppVersion.spec.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+import axios from 'axios'
+import useAppVersion from '../../composables/useAppVersion'
+
+vi.mock('axios')
+
+vi.stubGlobal('useRuntimeConfig', vi.fn(() => ({
+  public: { apiUrl: 'http://localhost:8080/api/' },
+})))
+
+describe('composables/useAppVersion', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.stubGlobal('useState', vi.fn((_key: string, init?: () => unknown) => ref(init ? init() : null)))
+  })
+
+  describe('fetchVersion', () => {
+    it('sets version from build.version on success', async () => {
+      vi.mocked(axios.get).mockResolvedValue({ data: { build: { version: '1.14.0' } } })
+
+      const { version, fetchVersion } = useAppVersion()
+      await fetchVersion()
+
+      expect(version.value).toBe('1.14.0')
+    })
+
+    it('calls the actuator/info endpoint with the correct URL', async () => {
+      vi.mocked(axios.get).mockResolvedValue({ data: { build: { version: '1.0.0' } } })
+
+      const { fetchVersion } = useAppVersion()
+      await fetchVersion()
+
+      expect(axios.get).toHaveBeenCalledWith('http://localhost:8080/actuator/info')
+    })
+
+    it('leaves version null when API fails', async () => {
+      vi.mocked(axios.get).mockRejectedValue(new Error('network error'))
+
+      const { version, fetchVersion } = useAppVersion()
+      await fetchVersion()
+
+      expect(version.value).toBeNull()
+    })
+
+    it('leaves version null when build.version is absent from the response', async () => {
+      vi.mocked(axios.get).mockResolvedValue({ data: {} })
+
+      const { version, fetchVersion } = useAppVersion()
+      await fetchVersion()
+
+      expect(version.value).toBeNull()
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Expose `/actuator/info` with build metadata (Spring Boot `buildInfo()`) — public, unauthenticated
- Add `useAppVersion` composable that fetches the version on mount, falls back silently on error
- Display `v<version>` in the sidebar footer in a small, muted monospace style

## Changes

**Application**
- `springBoot { buildInfo() }` in `application/build.gradle.kts` — injects version into `META-INF/build-info.properties` at build time
- Exposes `info` actuator endpoint + `management.info.build.enabled=true` in `application.properties`
- Permits `/actuator/info` without authentication in `SecurityConfig`

**Client**
- New `composables/useAppVersion.ts` — fetches `/actuator/info`, exposes reactive `version` ref
- `app-sidebar.vue` — calls composable on mount, renders `v1.x.x` badge in footer (hidden if unavailable)
- Stub added to `tests/setup.ts`, 4 unit tests in `tests/unit/useAppVersion.spec.ts`

## Test plan

- [ ] `./gradlew :application:test` — all green including `ActuatorInfoTest`
- [ ] `pnpm test` from `client/` — 274 tests green
- [ ] Deploy and verify `v<version>` appears in sidebar footer
- [ ] Verify badge is absent when backend is unreachable (no error shown)

🤖 Generated with [Claude Code](https://claude.com/claude-code)