### PR TITLE
feat(email-verification): implement full email verification flow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,7 +103,12 @@ For every backend feature or fix:
 
 3. **Layer order**: `domain` → `infrastructure` → `application` → `client`.
 
-4. **Full-suite green** before considering any task complete.
+4. **Input length limits — verify at task completion**:
+   - Backend: every `String` field in a request DTO must have `@Size` (see `docs/agents/instructions/backend.instructions.md` §1.4).
+   - Frontend: every text input must have `maxlength` matching the backend constraint (see `docs/agents/instructions/frontend.instructions.md`).
+   - Reference table: username/password `100`, email `255`, label `100`, description `500`, version `20`.
+
+5. **Full-suite green** before considering any task complete.
 
 ---
 

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -80,9 +80,8 @@ Then the system returns a validation failure
 > When the flag is disabled, `POST /api/user/create` returns HTTP 404 and the registration form is
 > hidden in the UI. When enabled, all scenarios above apply.
 >
-> **Note**: when the `email-verification` feature flag is enabled, registration behaviour adapts to the
-> subscription plan (see the *Email Verification* feature). When the flag is disabled, registration behaves
-> exactly as described above.
+> **Note**: self-registered users always go through the email verification flow (see *Email Verification*).
+> The welcome email scenario above still applies — the verification email is sent in addition to it.
 
 ---
 
@@ -715,48 +714,51 @@ Then it receives a map of every known flag key to its boolean state
 
 ## Feature: Email Verification
 
-As the system, I want to verify that users own a real mailbox. This is the inaugural feature flag
-(`email-verification`); behaviour adapts to the subscription plan, and the simple-user path is further gated by
-the sub-flag `email-verification-simple-user-registration`.
+As the system, I want to verify that self-registered users own a real mailbox.
+Admin-created users are implicitly trusted and marked as verified from creation.
 
-### Scenario: Beta tester is auto-confirmed via the access link
+### Scenario: Self-registered user must verify their email
 ```gherkin
-Given the flag "email-verification" is enabled
-And a BETA_TESTER received an access email with a valid token
-When the user follows the access link
-Then their emailVerified becomes true
+Given a visitor completes the registration form
+When the account is created
+Then emailVerified = false
+And a verification email with a unique token is sent
 ```
 
-### Scenario: Simple user receives a verification email and can still log in
+### Scenario: Admin-created user is auto-verified
 ```gherkin
-Given the flag "email-verification" is enabled
-And the sub-flag "email-verification-simple-user-registration" is enabled
-When a visitor registers
-Then the user is created with subscriptionPlan = FREE and emailVerified = false
-And a verification email is sent
-And the user can authenticate while seeing an "email not verified" indication
+Given an admin creates a user through the admin interface
+When the account is created
+Then emailVerified = true
+And no verification email is sent
 ```
 
-### Scenario: Verify email via token
+### Scenario: Valid token confirms the email
 ```gherkin
-Given a valid, unexpired verification token
-When the user confirms it
-Then their emailVerified becomes true
-And outstanding tokens are cleared
+Given a self-registered user with a valid, unexpired verification token
+When the user follows the link in the verification email
+Then emailVerified becomes true
+And all outstanding tokens for that user are cleared
 ```
 
 ### Scenario: Expired or unknown token is rejected
 ```gherkin
 Given a verification token that is expired or unknown
-When the user attempts to confirm it
+When the user follows the link
 Then the system returns a failure
-And emailVerified remains unchanged
+And emailVerified remains false
 ```
 
-### Scenario: Flag disabled keeps current behaviour
+### Scenario: Unverified user sees a warning indicator on the Paramètres tab
 ```gherkin
-Given the flag "email-verification" is disabled
-When a user registers
-Then no verification flow runs
-And no verified state is surfaced to the client
+Given an authenticated user with emailVerified = false
+When any authenticated page renders
+Then the "Paramètres" tab shows a warning indicator with tooltip "Votre compte doit être vérifié"
+```
+
+### Scenario: Unverified user can request a new verification email from settings
+```gherkin
+Given an authenticated user with emailVerified = false on the settings page
+When the user clicks "Vérifier mon e-mail"
+Then a new verification email is dispatched
 ```

--- a/application/src/main/kotlin/fr/sacane/jmanager/application/api/ApiMappingExtensions.kt
+++ b/application/src/main/kotlin/fr/sacane/jmanager/application/api/ApiMappingExtensions.kt
@@ -96,7 +96,13 @@ internal fun <T> Result<T>.toHttpResponse()
         this.errorInfo?.detail ?: this.message,
         this.errorInfo?.key,
     )
-    ResultState.TAG_IN_USE -> throw ConflictException(
+    ResultState.TAG_IN_USE,
+    ResultState.EMAIL_ALREADY_VERIFIED -> throw ConflictException(
+        this.errorInfo?.code ?: this.status.code,
+        this.errorInfo?.detail ?: this.message,
+        this.errorInfo?.key,
+    )
+    ResultState.EMAIL_VERIFICATION_TOKEN_EXPIRED -> throw GoneException(
         this.errorInfo?.code ?: this.status.code,
         this.errorInfo?.detail ?: this.message,
         this.errorInfo?.key,

--- a/application/src/main/kotlin/fr/sacane/jmanager/application/api/Exception.kt
+++ b/application/src/main/kotlin/fr/sacane/jmanager/application/api/Exception.kt
@@ -7,3 +7,4 @@ class InvalidRequestException(val errCode: Int, override val message: String, va
 class UnauthorizedRequestException(val errCode: Int, override val message: String, val errKey: String? = null): RuntimeException(message)
 class InternalServerErrorException(val errCode: Int, override val message: String, val errKey: String? = null) : RuntimeException(message)
 class ConflictException(val errCode: Int, override val message: String, val errKey: String? = null) : RuntimeException(message)
+class GoneException(val errCode: Int, override val message: String, val errKey: String? = null) : RuntimeException(message)

--- a/application/src/main/kotlin/fr/sacane/jmanager/application/api/ProblemDetailHandler.kt
+++ b/application/src/main/kotlin/fr/sacane/jmanager/application/api/ProblemDetailHandler.kt
@@ -102,6 +102,18 @@ class ProblemDetailHandler {
         )
     }
 
+    @ExceptionHandler(GoneException::class)
+    fun onGoneException(ex: GoneException): ResponseEntity<ProblemDetail> {
+        logException("Gone", ex.message)
+        return buildResponse(
+            status = HttpStatus.GONE,
+            title = "Gone",
+            detail = ex.message,
+            code = ex.errCode,
+            errorKey = ex.errKey,
+        )
+    }
+
     @ExceptionHandler(ConflictException::class)
     fun onConflictException(ex: ConflictException): ResponseEntity<ProblemDetail> {
         logException("Conflict", ex.cause?.message ?: ex.message)

--- a/application/src/main/kotlin/fr/sacane/jmanager/application/api/SecurityConfig.kt
+++ b/application/src/main/kotlin/fr/sacane/jmanager/application/api/SecurityConfig.kt
@@ -62,6 +62,7 @@ class SecurityConfig(
                 authorize("/api/user/create", permitAll)
                 authorize("/api/user/auth", permitAll)
                 authorize("/api/user/auth/refresh/**", permitAll)
+                authorize("/api/verify-email", permitAll)
                 // Protected API
                 authorize("/api/user/me", authenticated)
                 authorize("/api/admin/**", hasRole("ADMIN"))

--- a/application/src/main/kotlin/fr/sacane/jmanager/application/api/admin/Controller.kt
+++ b/application/src/main/kotlin/fr/sacane/jmanager/application/api/admin/Controller.kt
@@ -1,19 +1,27 @@
 package fr.sacane.jmanager.application.api.admin
 
+import fr.sacane.jmanager.application.api.InvalidRequestException
 import fr.sacane.jmanager.domain.hexadoc.Adapter
 import fr.sacane.jmanager.domain.models.Page
 import fr.sacane.jmanager.domain.models.UserId
+import fr.sacane.jmanager.domain.port.input.admin.AdminCreateUserCommand
 import fr.sacane.jmanager.domain.port.input.admin.GetUsersQuery
 import fr.sacane.jmanager.application.api.currentUser
 import fr.sacane.jmanager.application.api.session.UserDTO
 import fr.sacane.jmanager.application.api.toDTO
 import fr.sacane.jmanager.application.api.toHttpResponse
+import fr.sacane.jmanager.application.bus.CommandBus
 import fr.sacane.jmanager.application.bus.QueryBus
+import fr.sacane.jmanager.domain.utils.ResultState
+import jakarta.validation.Valid
 import jakarta.validation.constraints.Max
 import jakarta.validation.constraints.Min
+import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
@@ -24,13 +32,31 @@ import java.util.logging.Logger
 @Adapter
 @Validated
 class AdminController(
-    private val queryBus: QueryBus
+    private val queryBus: QueryBus,
+    private val commandBus: CommandBus,
 ) {
 
     companion object {
         val LOGGER: Logger = Logger.getLogger(AdminController::class.java.name)
     }
 
+    @PostMapping("/users", consumes = [MediaType.APPLICATION_JSON_VALUE])
+    fun createUser(@Valid @RequestBody request: AdminCreateUserRequest): ResponseEntity<UserDTO> {
+        if (request.password != request.confirmPassword) {
+            throw InvalidRequestException(
+                ResultState.INVALID.code,
+                "Les mots de passe ne correspondent pas",
+                "admin.user.create.password_mismatch",
+            )
+        }
+        return commandBus.dispatch(
+            AdminCreateUserCommand(
+                username = request.username,
+                password = request.password,
+                email = request.email,
+            )
+        ).map { it.toDTO() }.toHttpResponse()
+    }
 
     @GetMapping("/users")
     fun getCreatedUsers(

--- a/application/src/main/kotlin/fr/sacane/jmanager/application/api/admin/DTO.kt
+++ b/application/src/main/kotlin/fr/sacane/jmanager/application/api/admin/DTO.kt
@@ -1,0 +1,24 @@
+package fr.sacane.jmanager.application.api.admin
+
+import jakarta.validation.constraints.Email
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
+import kotlinx.serialization.Serializable
+
+/** Request payload for `POST /api/admin/users`. */
+@Serializable
+data class AdminCreateUserRequest(
+    @field:NotBlank
+    @field:Size(min = 1, max = 100)
+    val username: String,
+    @field:NotBlank
+    @field:Size(min = 1, max = 100)
+    val password: String,
+    @field:NotBlank
+    @field:Size(min = 1, max = 100)
+    val confirmPassword: String,
+    @field:NotBlank
+    @field:Email
+    @field:Size(max = 255)
+    val email: String,
+)

--- a/application/src/main/kotlin/fr/sacane/jmanager/application/api/session/Controller.kt
+++ b/application/src/main/kotlin/fr/sacane/jmanager/application/api/session/Controller.kt
@@ -9,6 +9,7 @@ import fr.sacane.jmanager.domain.models.SessionToken
 import fr.sacane.jmanager.domain.models.UserId
 import fr.sacane.jmanager.domain.port.input.user.DeleteAccountCommand
 import fr.sacane.jmanager.domain.port.input.user.GetUserSettingsQuery
+import fr.sacane.jmanager.domain.port.input.user.GetUserEmailVerifiedQuery
 import fr.sacane.jmanager.domain.port.input.user.HasUserConsentedQuery
 import fr.sacane.jmanager.domain.port.input.user.LoginCommand
 import fr.sacane.jmanager.domain.port.input.user.LogoutCommand
@@ -139,8 +140,10 @@ class SessionController(
      */
     @GetMapping(path = ["/me"])
     fun getUserStatus(): ResponseEntity<UserStatusDTO> {
-        return queryBus.dispatch(HasUserConsentedQuery(UserId(currentUser.id)))
-            .map { consented -> UserStatusDTO(consentRequired = !consented) }
+        val userId = UserId(currentUser.id)
+        val consented = queryBus.dispatch(HasUserConsentedQuery(userId)).mapNotNullOrFailure() ?: true
+        return queryBus.dispatch(GetUserEmailVerifiedQuery(userId))
+            .map { status -> UserStatusDTO(consentRequired = !consented, emailVerified = status.emailVerified, email = status.email) }
             .toHttpResponse()
     }
 

--- a/application/src/main/kotlin/fr/sacane/jmanager/application/api/session/DTO.kt
+++ b/application/src/main/kotlin/fr/sacane/jmanager/application/api/session/DTO.kt
@@ -10,10 +10,10 @@ import kotlinx.serialization.Serializable
 data class UserDTO(
     val id: String,
     val username: String,
+    val subscriptionPlan: String,
     val email: String? = null,
     val createdDate: String? = null,
     val roles: List<String> = emptyList(),
-    val subscriptionPlan: String = "BETA_TESTER",
 )
 
 @Serializable

--- a/application/src/main/kotlin/fr/sacane/jmanager/application/api/session/DTO.kt
+++ b/application/src/main/kotlin/fr/sacane/jmanager/application/api/session/DTO.kt
@@ -109,4 +109,8 @@ data class RecordConsentDTO(
 data class UserStatusDTO(
     /** `true` when the account was created without explicit consent (e.g. admin-created) and the user must go through the consent gate. */
     val consentRequired: Boolean,
+    /** `false` when the user has not yet clicked the verification link sent at registration. */
+    val emailVerified: Boolean = true,
+    /** The user's registered email address. */
+    val email: String? = null,
 )

--- a/application/src/main/kotlin/fr/sacane/jmanager/application/api/session/EmailVerificationController.kt
+++ b/application/src/main/kotlin/fr/sacane/jmanager/application/api/session/EmailVerificationController.kt
@@ -1,0 +1,42 @@
+package fr.sacane.jmanager.application.api.session
+
+import fr.sacane.jmanager.application.api.currentUser
+import fr.sacane.jmanager.application.api.toHttpResponse
+import fr.sacane.jmanager.application.bus.CommandBus
+import fr.sacane.jmanager.domain.hexadoc.Adapter
+import fr.sacane.jmanager.domain.hexadoc.Side
+import fr.sacane.jmanager.domain.models.UserId
+import fr.sacane.jmanager.domain.port.input.user.ResendVerificationEmailCommand
+import fr.sacane.jmanager.domain.port.input.user.VerifyEmailCommand
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("api/verify-email")
+@Adapter(Side.APPLICATION)
+class EmailVerificationController(
+    private val commandBus: CommandBus,
+) {
+
+    /**
+     * Consumes a verification token sent by email.
+     * Public — no authentication required (user may not be logged in when clicking the link).
+     * Returns 200 on success, 410 Gone on expiry, 404 on unknown token.
+     */
+    @GetMapping
+    fun verify(@RequestParam token: String): ResponseEntity<Unit> =
+        commandBus.dispatch(VerifyEmailCommand(token)).toHttpResponse()
+
+    /**
+     * Re-issues a verification token and sends a new verification email.
+     * Authenticated — the user must be logged in to request a resend.
+     * Returns 200 on success, 409 Conflict if already verified.
+     */
+    @PostMapping("/resend")
+    fun resend(): ResponseEntity<Unit> =
+        commandBus.dispatch(ResendVerificationEmailCommand(UserId(currentUser.id))).toHttpResponse()
+}

--- a/application/src/test/kotlin/fr/sacane/jmanager/application/api/AdminControllerTest.kt
+++ b/application/src/test/kotlin/fr/sacane/jmanager/application/api/AdminControllerTest.kt
@@ -1,5 +1,7 @@
 package fr.sacane.jmanager.application.api
 
+import com.fasterxml.jackson.databind.ObjectMapper
+import fr.sacane.jmanager.application.api.admin.AdminCreateUserRequest
 import fr.sacane.jmanager.domain.models.User
 import fr.sacane.jmanager.domain.port.input.user.*
 import fr.sacane.jmanager.infrastructure.spi.repositories.UserPostgresRepository
@@ -21,6 +23,7 @@ import java.time.LocalDateTime
 @TestPropertySource(locations = ["classpath:application-test.properties"])
 class AdminControllerTest(
     @LocalServerPort private val port: Int,
+    @Autowired val objectMapper: ObjectMapper,
     @Autowired val userRepository: UserPostgresRepository,
     @Autowired private val registerUserUseCase: RegisterUserUseCase,
     @Autowired private val loginUseCase: LoginUseCase,
@@ -50,6 +53,90 @@ class AdminControllerTest(
         username = username, password = "test", confirmPassword = "test", email = email,
         tosAcceptedAt = LocalDateTime.now(), tosVersion = "1.0", privacyAcceptedAt = LocalDateTime.now(),
     )
+
+    @Nested
+    inner class CreateUserEndpointTest {
+
+        private fun validRequest(
+            username: String = "betauser",
+            email: String = "beta@example.com",
+            password: String = "secret123",
+            confirmPassword: String = "secret123",
+        ) = AdminCreateUserRequest(username, password, confirmPassword, email)
+
+        @Test
+        fun `POST admin-users with admin token should return 200 with BETA_TESTER user`() {
+            Given {
+                port(port)
+                cookie("token", adminToken)
+                header("Content-Type", "application/json")
+                body(objectMapper.writeValueAsString(validRequest()))
+            } When {
+                post("/api/admin/users")
+            } Then {
+                statusCode(200)
+                body("username", equalTo("betauser"))
+                body("email", equalTo("beta@example.com"))
+                body("subscriptionPlan", equalTo("BETA_TESTER"))
+                body("id", notNullValue())
+            }
+        }
+
+        @Test
+        fun `POST admin-users without admin token should return 403`() {
+            Given {
+                port(port)
+                cookie("token", token)
+                header("Content-Type", "application/json")
+                body(objectMapper.writeValueAsString(validRequest()))
+            } When {
+                post("/api/admin/users")
+            } Then {
+                statusCode(403)
+            }
+        }
+
+        @Test
+        fun `POST admin-users without token should return 401`() {
+            Given {
+                port(port)
+                header("Content-Type", "application/json")
+                body(objectMapper.writeValueAsString(validRequest()))
+            } When {
+                post("/api/admin/users")
+            } Then {
+                statusCode(401)
+            }
+        }
+
+        @Test
+        fun `POST admin-users with mismatched passwords should return 400`() {
+            Given {
+                port(port)
+                cookie("token", adminToken)
+                header("Content-Type", "application/json")
+                body(objectMapper.writeValueAsString(validRequest(password = "abc123", confirmPassword = "different")))
+            } When {
+                post("/api/admin/users")
+            } Then {
+                statusCode(400)
+            }
+        }
+
+        @Test
+        fun `POST admin-users with blank email should return 400`() {
+            Given {
+                port(port)
+                cookie("token", adminToken)
+                header("Content-Type", "application/json")
+                body(objectMapper.writeValueAsString(validRequest(email = "")))
+            } When {
+                post("/api/admin/users")
+            } Then {
+                statusCode(400)
+            }
+        }
+    }
 
     @Nested
     inner class GetUsersEndpointTest {

--- a/client/components/app-sidebar.vue
+++ b/client/components/app-sidebar.vue
@@ -5,6 +5,7 @@ import useAuth from '../composables/useAuth'
 import 'primeicons/primeicons.css'
 
 const { isAuthenticated, isAdmin } = useAuth()
+const { emailVerified } = useConsent()
 const { version, fetchVersion } = useAppVersion()
 const isSidebarOpen = ref(false)
 const isMobileView = ref(false)
@@ -135,6 +136,14 @@ onUnmounted(() => {
             >
               <i class="pi pi-cog" />
               <span>Paramètres</span>
+              <span
+                v-if="!emailVerified"
+                v-tooltip.right="'Votre compte doit être vérifié'"
+                class="verify-badge"
+                aria-label="E-mail non vérifié"
+              >
+                <i class="pi pi-exclamation-triangle" />
+              </span>
             </NuxtLink>
 
             <NuxtLink
@@ -511,6 +520,19 @@ onUnmounted(() => {
       transform: translateX(2px);
       box-shadow: 0 4px 20px rgba(88, 28, 160, 0.55), inset 0 1px 0 rgba(255, 255, 255, 0.1);
     }
+  }
+}
+
+.verify-badge {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  color: #f59e0b;
+  font-size: 0.9rem;
+  flex-shrink: 0;
+
+  html.dark & {
+    color: #fbbf24;
   }
 }
 

--- a/client/composables/useAdmin.ts
+++ b/client/composables/useAdmin.ts
@@ -5,13 +5,21 @@ import { LOADING_SCOPES } from '~/constants/loadingScopes'
 export interface UserDTO {
   id: string
   username: string
+  subscriptionPlan: string
   email: string | null
   createdDate: string | null
   roles: string[]
 }
 
+export interface AdminCreateUserRequest {
+  username: string
+  password: string
+  confirmPassword: string
+  email: string
+}
+
 export default function useAdmin() {
-  const { get } = useQuery()
+  const { get, post } = useQuery()
   const loadingScope = LOADING_SCOPES.admin.fetchUsers
   const { isScopeLoading, withLoading } = useLoading()
   const users = ref<UserDTO[]>([])
@@ -48,6 +56,21 @@ export default function useAdmin() {
     }, loadingScope)
   }
 
+  async function createUser(
+    payload: AdminCreateUserRequest,
+    onSuccess: () => void,
+    onError: (error: AxiosError) => void,
+  ) {
+    await withLoading(async () => {
+      try {
+        await post('admin/users', payload)
+        onSuccess()
+      } catch (error) {
+        onError(error as AxiosError)
+      }
+    }, LOADING_SCOPES.admin.createUser)
+  }
+
   return {
     users,
     totalUsers,
@@ -56,5 +79,6 @@ export default function useAdmin() {
     pageSize,
     isLoading,
     fetchUsers,
+    createUser,
   }
 }

--- a/client/composables/useConsent.ts
+++ b/client/composables/useConsent.ts
@@ -3,6 +3,8 @@ import { LOADING_SCOPES } from '~/constants/loadingScopes'
 
 interface UserStatusDTO {
   consentRequired: boolean
+  emailVerified?: boolean
+  email?: string | null
 }
 
 /** Current TOS version — update here when terms are revised. */
@@ -12,6 +14,9 @@ export default function useConsent() {
   // useState persists across navigations in the same SPA session — HTTP call made only once.
   const consentChecked = useState<boolean>('consent:checked', () => false)
   const consentRequired = useState<boolean>('consent:required', () => false)
+  // Default true to avoid banner flash before the first /me call completes.
+  const emailVerified = useState<boolean>('consent:emailVerified', () => true)
+  const userEmail = useState<string | null>('consent:userEmail', () => null)
 
   const tosAccepted = ref(false)
   const privacyAccepted = ref(false)
@@ -30,6 +35,8 @@ export default function useConsent() {
     try {
       const data = await get('user/me') as UserStatusDTO | undefined
       consentRequired.value = data?.consentRequired ?? false
+      emailVerified.value = data?.emailVerified ?? true
+      userEmail.value = data?.email ?? null
     } catch {
       // Fail open: if the check fails, don't block the user
       consentRequired.value = false
@@ -70,6 +77,8 @@ export default function useConsent() {
   function clearConsentCache(): void {
     consentChecked.value = false
     consentRequired.value = false
+    emailVerified.value = true
+    userEmail.value = null
   }
 
   return {
@@ -80,6 +89,8 @@ export default function useConsent() {
     tosVersion: CURRENT_TOS_VERSION,
     consentRequired: readonly(consentRequired),
     consentChecked: readonly(consentChecked),
+    emailVerified: readonly(emailVerified),
+    userEmail: readonly(userEmail),
     checkConsentStatus,
     submitConsent,
     clearConsentCache,

--- a/client/composables/useEmailVerification.ts
+++ b/client/composables/useEmailVerification.ts
@@ -1,0 +1,81 @@
+import type { AxiosError } from 'axios'
+import { LOADING_SCOPES } from '~/constants/loadingScopes'
+
+type VerifyResult = 'success' | 'expired' | 'not_found' | 'error'
+
+const RESEND_COOLDOWN_SECONDS = 60
+
+export default function useEmailVerification() {
+  const { get, post } = useQuery()
+  const { isScopeLoading, withLoading } = useLoading()
+
+  const verifyResult = ref<VerifyResult | null>(null)
+  const resendCooldown = ref(0)
+  let cooldownInterval: ReturnType<typeof setInterval> | null = null
+
+  const isVerifying = computed(() => isScopeLoading(LOADING_SCOPES.emailVerification.verify))
+  const isResending = computed(() => isScopeLoading(LOADING_SCOPES.emailVerification.resend))
+  const isResendOnCooldown = computed(() => resendCooldown.value > 0)
+
+  async function verifyEmail(token: string): Promise<VerifyResult> {
+    let result: VerifyResult = 'error'
+    await withLoading(async () => {
+      try {
+        await get(`verify-email?token=${encodeURIComponent(token)}`)
+        result = 'success'
+      } catch (err) {
+        const axiosError = err as AxiosError
+        const status = axiosError.response?.status
+        if (status === 410) {
+          result = 'expired'
+        } else if (status === 404) {
+          result = 'not_found'
+        } else {
+          result = 'error'
+        }
+      }
+    }, LOADING_SCOPES.emailVerification.verify)
+    verifyResult.value = result
+    return result
+  }
+
+  async function resendVerificationEmail(
+    onSuccess?: () => void,
+    onError?: (error: AxiosError) => void,
+  ): Promise<void> {
+    await withLoading(async () => {
+      try {
+        await post('verify-email/resend', undefined)
+        startCooldown()
+        onSuccess?.()
+      } catch (err) {
+        onError?.(err as AxiosError)
+      }
+    }, LOADING_SCOPES.emailVerification.resend)
+  }
+
+  function startCooldown(): void {
+    resendCooldown.value = RESEND_COOLDOWN_SECONDS
+    if (cooldownInterval) clearInterval(cooldownInterval)
+    cooldownInterval = setInterval(() => {
+      resendCooldown.value -= 1
+      if (resendCooldown.value <= 0) {
+        resendCooldown.value = 0
+        if (cooldownInterval) {
+          clearInterval(cooldownInterval)
+          cooldownInterval = null
+        }
+      }
+    }, 1000)
+  }
+
+  return {
+    verifyResult: readonly(verifyResult),
+    isVerifying,
+    isResending,
+    isResendOnCooldown,
+    resendCooldown: readonly(resendCooldown),
+    verifyEmail,
+    resendVerificationEmail,
+  }
+}

--- a/client/constants/loadingScopes.ts
+++ b/client/constants/loadingScopes.ts
@@ -39,4 +39,8 @@ export const LOADING_SCOPES = {
     fetch: 'featureFlags.fetch',
     toggle: 'featureFlags.toggle',
   },
+  emailVerification: {
+    verify: 'emailVerification.verify',
+    resend: 'emailVerification.resend',
+  },
 } as const

--- a/client/pages/admin/index.vue
+++ b/client/pages/admin/index.vue
@@ -16,8 +16,7 @@ definePageMeta({
 
 // ── User management ──────────────────────────────────────────────────────────
 
-const { register } = useAuth()
-const { users, totalUsers, totalPages, currentPage, isLoading, fetchUsers } = useAdmin()
+const { users, totalUsers, totalPages, currentPage, isLoading, fetchUsers, createUser } = useAdmin()
 const { isScopeLoading, withLoading } = useLoading()
 const toastr = useJToast()
 
@@ -41,7 +40,7 @@ function resetForm() {
   }
 }
 
-async function createUser() {
+async function submitCreateUser() {
   if (!newUser.value.username || !newUser.value.email || !newUser.value.password) {
     toastr.error('Veuillez remplir tous les champs')
     return
@@ -63,19 +62,17 @@ async function createUser() {
     return
   }
 
-  await withLoading(async () => {
-    await register(
-      newUser.value,
-      () => {
-        toastr.success(`Utilisateur ${newUser.value.username} créé avec succès`)
-        resetForm()
-        loadUsers()
-      },
-      (error) => {
-        toastr.errorAxios(error)
-      },
-    )
-  }, userCreationLoadingScope)
+  await createUser(
+    newUser.value,
+    () => {
+      toastr.success(`Utilisateur ${newUser.value.username} créé avec succès`)
+      resetForm()
+      loadUsers()
+    },
+    (error) => {
+      toastr.errorAxios(error)
+    },
+  )
 }
 
 async function loadUsers(page: number = 0) {
@@ -230,7 +227,7 @@ function isKeyToggling(key: FeatureKey): boolean {
                   </div>
                 </div>
 
-                <form class="user-form" @submit.prevent="createUser">
+                <form class="user-form" @submit.prevent="submitCreateUser">
                   <div class="form-group">
                     <label for="username" class="form-label">
                       <i class="pi pi-user" />

--- a/client/pages/settings/index.vue
+++ b/client/pages/settings/index.vue
@@ -3,6 +3,9 @@ import useUserSettings from '~/composables/useUserSettings'
 import { LOADING_SCOPES } from '~/constants/loadingScopes'
 import authMiddleware from '~/middleware/auth'
 
+const { emailVerified, userEmail } = useConsent()
+const { resendVerificationEmail, isResending, isResendOnCooldown, resendCooldown } = useEmailVerification()
+
 definePageMeta({
   layout: 'sidebar-layout',
   middleware: [authMiddleware],
@@ -11,6 +14,13 @@ definePageMeta({
 const { getSettings, updateSettings } = useUserSettings()
 const { withLoading, isScopeLoading } = useLoading()
 const toast = useJToast()
+
+async function handleResend() {
+  await resendVerificationEmail(
+    () => toast.success('E-mail de vérification envoyé. Vérifiez votre boîte de réception.'),
+    () => toast.error('Impossible d\'envoyer l\'e-mail de vérification.'),
+  )
+}
 
 const loadSettingsScope = LOADING_SCOPES.settings.load
 const saveSettingsScope = LOADING_SCOPES.settings.save
@@ -187,6 +197,37 @@ onMounted(() => {
         </div>
       </section>
     </div>
+
+      <section v-if="!emailVerified" class="settings-card email-verification-card" data-test="email-verification-section">
+        <div class="email-verification-header">
+          <div class="email-verification-icon">
+            <i class="pi pi-exclamation-triangle" aria-hidden="true" />
+          </div>
+          <div>
+            <h2>Vérification de l'e-mail</h2>
+            <p class="settings-help">
+              Votre adresse e-mail n'est pas encore vérifiée.
+            </p>
+          </div>
+        </div>
+
+        <div v-if="userEmail" class="email-verification-address" data-test="email-display">
+          <span class="settings-label">Adresse e-mail</span>
+          <span class="email-value">{{ userEmail }}</span>
+        </div>
+
+        <button
+          class="verify-btn"
+          data-test="resend-verification-btn"
+          :disabled="isResending || isResendOnCooldown"
+          @click="handleResend"
+        >
+          <i class="pi pi-envelope" aria-hidden="true" />
+          <span v-if="isResending">Envoi en cours…</span>
+          <span v-else-if="isResendOnCooldown">Renvoyer dans {{ resendCooldown }}s</span>
+          <span v-else>Vérifier mon e-mail</span>
+        </button>
+      </section>
 
     <div class="actions">
       <button class="save-btn" data-test="save-settings-btn" :disabled="isSaving" @click="saveUserSettings">
@@ -366,6 +407,79 @@ onMounted(() => {
 .save-btn:disabled {
   opacity: 0.7;
   cursor: not-allowed;
+}
+
+.email-verification-card {
+  border-color: #f59e0b;
+  background-color: #fffbeb;
+
+  .dark & {
+    background-color: rgba(245, 158, 11, 0.07);
+    border-color: rgba(245, 158, 11, 0.4);
+  }
+}
+
+.email-verification-header {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+}
+
+.email-verification-icon {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: 50%;
+  background: rgba(245, 158, 11, 0.15);
+  color: #f59e0b;
+  font-size: 1rem;
+
+  .dark & {
+    background: rgba(245, 158, 11, 0.12);
+    color: #fbbf24;
+  }
+}
+
+.email-verification-address {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  margin-bottom: 1rem;
+}
+
+.email-value {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  word-break: break-all;
+}
+
+.verify-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  border: none;
+  border-radius: 0.75rem;
+  padding: 0.6rem 1.1rem;
+  background: linear-gradient(135deg, #f59e0b 0%, #d97706 100%);
+  color: #fff;
+  font-weight: 600;
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: opacity 0.2s ease;
+
+  &:hover:not(:disabled) {
+    opacity: 0.9;
+  }
+
+  &:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
 }
 
 @media (max-width: 640px) {

--- a/client/pages/verify-email.vue
+++ b/client/pages/verify-email.vue
@@ -1,0 +1,119 @@
+<script setup lang="ts">
+definePageMeta({
+  layout: 'centercard',
+})
+
+const route = useRoute()
+const { verifyEmail, isVerifying, verifyResult, resendVerificationEmail, isResending, isResendOnCooldown, resendCooldown } = useEmailVerification()
+const { emailVerified } = useConsent()
+const toast = useJToast()
+
+const token = computed(() => {
+  const raw = route.query.token
+  return typeof raw === 'string' ? raw : null
+})
+
+onMounted(async () => {
+  if (!token.value) return
+  const result = await verifyEmail(token.value)
+  if (result === 'success') {
+    // Refresh the cached verification state so the sidebar badge disappears.
+    emailVerified.value = true
+  }
+})
+
+async function handleResend() {
+  await resendVerificationEmail(
+    () => toast.success('E-mail de vérification envoyé. Vérifiez votre boîte de réception.'),
+    () => toast.error('Impossible d\'envoyer l\'e-mail de vérification.'),
+  )
+}
+</script>
+
+<template>
+  <div class="flex flex-col gap-6 text-center">
+    <!-- Loading -->
+    <template v-if="isVerifying || (!verifyResult && token)">
+      <div class="inline-flex items-center justify-center w-16 h-16 rounded-full bg-[var(--primary)] mx-auto mb-2">
+        <i class="pi pi-spin pi-spinner text-white text-2xl" aria-hidden="true" />
+      </div>
+      <p class="body-base">
+        Vérification en cours…
+      </p>
+    </template>
+
+    <!-- No token provided -->
+    <template v-else-if="!token">
+      <div class="inline-flex items-center justify-center w-16 h-16 rounded-full bg-red-100 dark:bg-red-900/20 mx-auto mb-2">
+        <i class="pi pi-times-circle text-red-500 text-2xl" aria-hidden="true" />
+      </div>
+      <h1 class="heading-2">
+        Lien invalide
+      </h1>
+      <p class="body-base max-w-sm mx-auto">
+        Ce lien de vérification est invalide. Vérifiez que vous avez copié l'URL complète.
+      </p>
+      <NuxtLink to="/" class="btn-primary w-full text-center">
+        Accéder à l'application
+      </NuxtLink>
+    </template>
+
+    <!-- Success -->
+    <template v-else-if="verifyResult === 'success'">
+      <div class="inline-flex items-center justify-center w-16 h-16 rounded-full bg-green-100 dark:bg-green-900/20 mx-auto mb-2">
+        <i class="pi pi-check-circle text-green-500 text-2xl" aria-hidden="true" />
+      </div>
+      <h1 class="heading-2">
+        E-mail vérifié !
+      </h1>
+      <p class="body-base max-w-sm mx-auto">
+        Votre adresse e-mail a été vérifiée avec succès.
+      </p>
+      <NuxtLink to="/" class="btn-primary w-full text-center" data-test="go-to-app-link">
+        Accéder à l'application
+      </NuxtLink>
+    </template>
+
+    <!-- Expired token -->
+    <template v-else-if="verifyResult === 'expired'">
+      <div class="inline-flex items-center justify-center w-16 h-16 rounded-full bg-amber-100 dark:bg-amber-900/20 mx-auto mb-2">
+        <i class="pi pi-clock text-amber-500 text-2xl" aria-hidden="true" />
+      </div>
+      <h1 class="heading-2">
+        Lien expiré
+      </h1>
+      <p class="body-base max-w-sm mx-auto">
+        Ce lien de vérification a expiré. Vous pouvez en demander un nouveau.
+      </p>
+      <button
+        class="btn-primary w-full"
+        data-test="expired-resend-btn"
+        :disabled="isResending || isResendOnCooldown"
+        @click="handleResend"
+      >
+        <span v-if="isResending">Envoi en cours…</span>
+        <span v-else-if="isResendOnCooldown">Renvoyer dans {{ resendCooldown }}s</span>
+        <span v-else>Renvoyer un e-mail de vérification</span>
+      </button>
+      <NuxtLink to="/login" class="btn-outline-primary w-full text-center">
+        Se connecter
+      </NuxtLink>
+    </template>
+
+    <!-- Unknown / not found -->
+    <template v-else>
+      <div class="inline-flex items-center justify-center w-16 h-16 rounded-full bg-red-100 dark:bg-red-900/20 mx-auto mb-2">
+        <i class="pi pi-times-circle text-red-500 text-2xl" aria-hidden="true" />
+      </div>
+      <h1 class="heading-2">
+        Lien invalide
+      </h1>
+      <p class="body-base max-w-sm mx-auto">
+        Ce lien de vérification n'est pas reconnu. Il a peut-être déjà été utilisé.
+      </p>
+      <NuxtLink to="/login" class="btn-primary w-full text-center">
+        Se connecter
+      </NuxtLink>
+    </template>
+  </div>
+</template>

--- a/client/tests/pages/admin.spec.ts
+++ b/client/tests/pages/admin.spec.ts
@@ -56,12 +56,12 @@ const TabPanelStub = {
 
 // ---------------------------------------------------------------------------
 describe('pages/admin/index', () => {
-  let registerMock: ReturnType<typeof vi.fn>
+  let createUserMock: ReturnType<typeof vi.fn>
   let toastrErrorMock: ReturnType<typeof vi.fn>
   let toastrSuccessMock: ReturnType<typeof vi.fn>
 
   beforeEach(() => {
-    registerMock = vi.fn()
+    createUserMock = vi.fn()
     toastrErrorMock = vi.fn()
     toastrSuccessMock = vi.fn()
 
@@ -70,7 +70,7 @@ describe('pages/admin/index', () => {
       isAuthenticated: ref(false) as any,
       login: vi.fn(),
       logout: vi.fn(),
-      register: registerMock,
+      register: vi.fn(),
       isAdmin: ref(true) as any,
       tryRefresh: vi.fn(),
       initializeSession: vi.fn(),
@@ -84,7 +84,8 @@ describe('pages/admin/index', () => {
       pageSize: ref(10) as any,
       isLoading: ref(false) as any,
       fetchUsers: vi.fn(),
-    })
+      createUser: createUserMock,
+    } as any)
 
     vi.stubGlobal('useJToast', () => ({
       success: toastrSuccessMock,
@@ -177,7 +178,7 @@ describe('pages/admin/index', () => {
     await wrapper.find('form').trigger('submit')
 
     expect(toastrErrorMock).toHaveBeenCalledWith('Veuillez remplir tous les champs')
-    expect(registerMock).not.toHaveBeenCalled()
+    expect(createUserMock).not.toHaveBeenCalled()
   })
 
   it('shows an error when email is empty', async () => {
@@ -187,7 +188,7 @@ describe('pages/admin/index', () => {
     await wrapper.find('form').trigger('submit')
 
     expect(toastrErrorMock).toHaveBeenCalledWith('Veuillez remplir tous les champs')
-    expect(registerMock).not.toHaveBeenCalled()
+    expect(createUserMock).not.toHaveBeenCalled()
   })
 
   it('shows an error when the email format is invalid', async () => {
@@ -197,7 +198,7 @@ describe('pages/admin/index', () => {
     await wrapper.find('form').trigger('submit')
 
     expect(toastrErrorMock).toHaveBeenCalledWith("L'adresse email n'est pas valide")
-    expect(registerMock).not.toHaveBeenCalled()
+    expect(createUserMock).not.toHaveBeenCalled()
   })
 
   it('shows an error when passwords do not match', async () => {
@@ -207,7 +208,7 @@ describe('pages/admin/index', () => {
     await wrapper.find('form').trigger('submit')
 
     expect(toastrErrorMock).toHaveBeenCalledWith('Les mots de passe ne correspondent pas')
-    expect(registerMock).not.toHaveBeenCalled()
+    expect(createUserMock).not.toHaveBeenCalled()
   })
 
   it('shows an error when the password is shorter than 6 characters', async () => {
@@ -217,12 +218,12 @@ describe('pages/admin/index', () => {
     await wrapper.find('form').trigger('submit')
 
     expect(toastrErrorMock).toHaveBeenCalledWith('Le mot de passe doit contenir au moins 6 caractères')
-    expect(registerMock).not.toHaveBeenCalled()
+    expect(createUserMock).not.toHaveBeenCalled()
   })
 
   // --- Successful submission ---
 
-  it('calls register with username, email, password and confirmPassword on valid form', async () => {
+  it('calls createUser with username, email, password and confirmPassword on valid form', async () => {
     const wrapper = mountPage()
     await setFormValues(wrapper, {
       username: 'alice',
@@ -235,7 +236,7 @@ describe('pages/admin/index', () => {
     await flushPromises()
 
     expect(toastrErrorMock).not.toHaveBeenCalled()
-    expect(registerMock).toHaveBeenCalledWith(
+    expect(createUserMock).toHaveBeenCalledWith(
       expect.objectContaining({
         username: 'alice',
         email: 'alice@example.com',

--- a/client/tests/pages/settings-index.spec.ts
+++ b/client/tests/pages/settings-index.spec.ts
@@ -37,12 +37,35 @@ function flushPromises() {
   return new Promise(resolve => setTimeout(resolve, 0))
 }
 
-function mountSettingsPage(activeScopes: string[] = []) {
+function mountSettingsPage(activeScopes: string[] = [], emailVerified = true) {
   vi.stubGlobal('definePageMeta', vi.fn())
   vi.stubGlobal('useJToast', () => ({ success: vi.fn(), error: vi.fn() }))
   vi.stubGlobal('useLoading', () => ({
     isScopeLoading: (scope: string) => activeScopes.includes(scope),
     withLoading: async <T>(action: () => Promise<T>) => action(),
+  }))
+  vi.stubGlobal('useConsent', () => ({
+    emailVerified: ref(emailVerified),
+    userEmail: ref('user@example.com'),
+    consentRequired: ref(false),
+    consentChecked: ref(false),
+    tosAccepted: ref(false),
+    privacyAccepted: ref(false),
+    canSubmit: { value: false },
+    isSubmitting: { value: false },
+    tosVersion: '1.0',
+    checkConsentStatus: vi.fn(),
+    submitConsent: vi.fn(),
+    clearConsentCache: vi.fn(),
+  }))
+  vi.stubGlobal('useEmailVerification', () => ({
+    verifyResult: ref(null),
+    isVerifying: ref(false),
+    isResending: ref(false),
+    isResendOnCooldown: ref(false),
+    resendCooldown: ref(0),
+    verifyEmail: vi.fn(),
+    resendVerificationEmail: vi.fn(),
   }))
 
   return shallowMount(SettingsPage)
@@ -61,6 +84,24 @@ describe('pages/settings/index', () => {
     expect(wrapper.text()).toContain('Projection')
     expect(wrapper.text()).toContain('Cycle mensuel par compte')
     expect(wrapper.text()).toContain('Compte principal')
+  })
+
+  it('hides email verification section when emailVerified is true', async () => {
+    const wrapper = mountSettingsPage([], true)
+    await flushPromises()
+    expect(wrapper.find('[data-test="email-verification-section"]').exists()).toBe(false)
+  })
+
+  it('shows email verification section when emailVerified is false', async () => {
+    const wrapper = mountSettingsPage([], false)
+    await flushPromises()
+    expect(wrapper.find('[data-test="email-verification-section"]').exists()).toBe(true)
+  })
+
+  it('displays the user email in the verification section', async () => {
+    const wrapper = mountSettingsPage([], false)
+    await flushPromises()
+    expect(wrapper.find('[data-test="email-display"]').text()).toContain('user@example.com')
   })
 
   it('submits updated settings payload', async () => {

--- a/client/tests/pages/verify-email.spec.ts
+++ b/client/tests/pages/verify-email.spec.ts
@@ -1,0 +1,107 @@
+import { shallowMount } from '@vue/test-utils'
+import { computed, ref } from 'vue'
+import { describe, expect, it, vi } from 'vitest'
+import VerifyEmailPage from '../../pages/verify-email.vue'
+
+function flushPromises() {
+  return new Promise(resolve => setTimeout(resolve, 0))
+}
+
+function mountPage(options: {
+  token?: string | null
+  verifyResult?: string | null
+  verifyEmail?: ReturnType<typeof vi.fn>
+  emailVerifiedRef?: ReturnType<typeof ref<boolean>>
+} = {}) {
+  const {
+    token = 'test-token',
+    verifyResult = null,
+    verifyEmail = vi.fn().mockResolvedValue('success'),
+    emailVerifiedRef = ref(false),
+  } = options
+
+  vi.stubGlobal('useRoute', () => ({
+    params: {},
+    query: token ? { token } : {},
+  }))
+
+  vi.stubGlobal('useEmailVerification', () => ({
+    verifyResult: ref(verifyResult),
+    isVerifying: ref(false),
+    isResending: ref(false),
+    isResendOnCooldown: ref(false),
+    resendCooldown: ref(0),
+    verifyEmail,
+    resendVerificationEmail: vi.fn(),
+  }))
+
+  vi.stubGlobal('useConsent', () => ({
+    emailVerified: emailVerifiedRef,
+    userEmail: ref(null),
+    consentRequired: ref(false),
+    consentChecked: ref(false),
+    tosAccepted: ref(false),
+    privacyAccepted: ref(false),
+    canSubmit: computed(() => false),
+    isSubmitting: computed(() => false),
+    tosVersion: '1.0',
+    checkConsentStatus: vi.fn(),
+    submitConsent: vi.fn(),
+    clearConsentCache: vi.fn(),
+  }))
+
+  return shallowMount(VerifyEmailPage, {
+    global: {
+      stubs: {
+        NuxtLink: { template: '<a><slot /></a>' },
+      },
+    },
+  })
+}
+
+describe('pages/verify-email', () => {
+  it('calls verifyEmail with the token on mount', async () => {
+    const verifyEmail = vi.fn().mockResolvedValue('success')
+    mountPage({ verifyEmail })
+    await flushPromises()
+    expect(verifyEmail).toHaveBeenCalledWith('test-token')
+  })
+
+  it('shows invalid link when no token is in the query', async () => {
+    const wrapper = mountPage({ token: null, verifyResult: null })
+    await flushPromises()
+    expect(wrapper.text()).toContain('Lien invalide')
+  })
+
+  it('shows success state when verifyResult is success', async () => {
+    const wrapper = mountPage({ verifyResult: 'success' })
+    await flushPromises()
+    expect(wrapper.text()).toContain('E-mail vérifié')
+  })
+
+  it('shows expired state when verifyResult is expired', async () => {
+    const wrapper = mountPage({ verifyResult: 'expired' })
+    await flushPromises()
+    expect(wrapper.text()).toContain('Lien expiré')
+  })
+
+  it('shows invalid link state when verifyResult is not_found', async () => {
+    const wrapper = mountPage({ verifyResult: 'not_found' })
+    await flushPromises()
+    expect(wrapper.text()).toContain('Lien invalide')
+  })
+
+  it('sets emailVerified to true on successful verification', async () => {
+    const emailVerifiedRef = ref(false)
+    mountPage({ emailVerifiedRef, verifyEmail: vi.fn().mockResolvedValue('success') })
+    await flushPromises()
+    expect(emailVerifiedRef.value).toBe(true)
+  })
+
+  it('does not set emailVerified when verification fails', async () => {
+    const emailVerifiedRef = ref(false)
+    mountPage({ emailVerifiedRef, verifyEmail: vi.fn().mockResolvedValue('expired') })
+    await flushPromises()
+    expect(emailVerifiedRef.value).toBe(false)
+  })
+})

--- a/client/tests/setup.ts
+++ b/client/tests/setup.ts
@@ -137,6 +137,7 @@ vi.stubGlobal('useAdmin', vi.fn(() => ({
   pageSize: ref(10),
   isLoading: ref(false),
   fetchUsers: vi.fn(),
+  createUser: vi.fn(),
 })))
 
 vi.stubGlobal('useAppVersion', vi.fn(() => ({

--- a/client/tests/setup.ts
+++ b/client/tests/setup.ts
@@ -112,9 +112,21 @@ vi.stubGlobal('useConsent', vi.fn(() => ({
   tosVersion: '1.0',
   consentRequired: ref(false),
   consentChecked: ref(false),
+  emailVerified: ref(true),
+  userEmail: ref(null),
   checkConsentStatus: vi.fn().mockResolvedValue(false),
   submitConsent: vi.fn(),
   clearConsentCache: vi.fn(),
+})))
+
+vi.stubGlobal('useEmailVerification', vi.fn(() => ({
+  verifyResult: ref(null),
+  isVerifying: ref(false),
+  isResending: ref(false),
+  isResendOnCooldown: ref(false),
+  resendCooldown: ref(0),
+  verifyEmail: vi.fn().mockResolvedValue('success'),
+  resendVerificationEmail: vi.fn(),
 })))
 
 vi.stubGlobal('useAdmin', vi.fn(() => ({

--- a/client/tests/unit/useAdmin.spec.ts
+++ b/client/tests/unit/useAdmin.spec.ts
@@ -4,11 +4,13 @@ import useAdmin from '../../composables/useAdmin'
 
 describe('composables/useAdmin', () => {
   const get = vi.fn()
+  const post = vi.fn()
 
   beforeEach(() => {
     get.mockReset()
+    post.mockReset()
 
-    vi.stubGlobal('useQuery', () => ({ get }))
+    vi.stubGlobal('useQuery', () => ({ get, post }))
 
     vi.stubGlobal('useLoading', () => {
       const activeScope = ref<string | null>(null)
@@ -70,5 +72,38 @@ describe('composables/useAdmin', () => {
 
     expect(onError).toHaveBeenCalledTimes(1)
     expect(isLoading.value).toBe(false)
+  })
+
+  it('createUser calls POST admin/users and invokes onSuccess on success', async () => {
+    post.mockResolvedValue({ id: 'u-1', username: 'beta', subscriptionPlan: 'BETA_TESTER' })
+
+    const { createUser } = useAdmin()
+    const onSuccess = vi.fn()
+    const onError = vi.fn()
+
+    await createUser({ username: 'beta', password: 'pass', confirmPassword: 'pass', email: 'beta@example.com' }, onSuccess, onError)
+
+    expect(post).toHaveBeenCalledWith('admin/users', {
+      username: 'beta',
+      password: 'pass',
+      confirmPassword: 'pass',
+      email: 'beta@example.com',
+    })
+    expect(onSuccess).toHaveBeenCalledTimes(1)
+    expect(onError).not.toHaveBeenCalled()
+  })
+
+  it('createUser calls onError when the request fails', async () => {
+    const error = new Error('network error')
+    post.mockRejectedValue(error)
+
+    const { createUser } = useAdmin()
+    const onSuccess = vi.fn()
+    const onError = vi.fn()
+
+    await createUser({ username: 'beta', password: 'pass', confirmPassword: 'pass', email: 'beta@example.com' }, onSuccess, onError)
+
+    expect(onError).toHaveBeenCalledTimes(1)
+    expect(onSuccess).not.toHaveBeenCalled()
   })
 })

--- a/client/tests/unit/useConsent.spec.ts
+++ b/client/tests/unit/useConsent.spec.ts
@@ -47,6 +47,25 @@ describe('composables/useConsent', () => {
       expect(result).toBe(false)
     })
 
+    it('populates emailVerified from the API response', async () => {
+      getMock.mockResolvedValue({ consentRequired: false, emailVerified: false, email: 'user@example.com' })
+
+      const { checkConsentStatus, emailVerified, userEmail } = useConsent()
+      await checkConsentStatus()
+
+      expect(emailVerified.value).toBe(false)
+      expect(userEmail.value).toBe('user@example.com')
+    })
+
+    it('defaults emailVerified to true when not in the API response', async () => {
+      getMock.mockResolvedValue({ consentRequired: false })
+
+      const { checkConsentStatus, emailVerified } = useConsent()
+      await checkConsentStatus()
+
+      expect(emailVerified.value).toBe(true)
+    })
+
     it('returns false and does not throw when the API call fails', async () => {
       getMock.mockRejectedValue(new Error('network error'))
 
@@ -122,16 +141,18 @@ describe('composables/useConsent', () => {
   // clearConsentCache
   // -------------------------------------------------------------------------
   describe('clearConsentCache', () => {
-    it('resets consentChecked and consentRequired', async () => {
-      getMock.mockResolvedValue({ consentRequired: true })
+    it('resets consentChecked, consentRequired, emailVerified and userEmail', async () => {
+      getMock.mockResolvedValue({ consentRequired: true, emailVerified: false, email: 'x@x.com' })
 
-      const { checkConsentStatus, clearConsentCache, consentRequired, consentChecked } = useConsent()
+      const { checkConsentStatus, clearConsentCache, consentRequired, consentChecked, emailVerified, userEmail } = useConsent()
       await checkConsentStatus() // primes the cache
 
       clearConsentCache()
 
       expect(consentChecked.value).toBe(false)
       expect(consentRequired.value).toBe(false)
+      expect(emailVerified.value).toBe(true)
+      expect(userEmail.value).toBe(null)
     })
   })
 

--- a/client/tests/unit/useEmailVerification.spec.ts
+++ b/client/tests/unit/useEmailVerification.spec.ts
@@ -1,0 +1,115 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+import useEmailVerification from '../../composables/useEmailVerification'
+
+const getMock = vi.fn()
+const postMock = vi.fn()
+vi.stubGlobal('useQuery', () => ({ get: getMock, post: postMock }))
+vi.stubGlobal('useLoading', () => ({
+  isScopeLoading: vi.fn(() => false),
+  withLoading: async <T>(action: () => Promise<T>) => action(),
+}))
+
+describe('composables/useEmailVerification', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.stubGlobal('useState', vi.fn((_key: string, init?: () => unknown) => ref(init ? init() : null)))
+  })
+
+  describe('verifyEmail', () => {
+    it('returns "success" when the API responds 200', async () => {
+      getMock.mockResolvedValue(undefined)
+
+      const { verifyEmail, verifyResult } = useEmailVerification()
+      const result = await verifyEmail('valid-token')
+
+      expect(result).toBe('success')
+      expect(verifyResult.value).toBe('success')
+    })
+
+    it('returns "expired" when the API responds 410', async () => {
+      getMock.mockRejectedValue({ response: { status: 410 } })
+
+      const { verifyEmail } = useEmailVerification()
+      const result = await verifyEmail('expired-token')
+
+      expect(result).toBe('expired')
+    })
+
+    it('returns "not_found" when the API responds 404', async () => {
+      getMock.mockRejectedValue({ response: { status: 404 } })
+
+      const { verifyEmail } = useEmailVerification()
+      const result = await verifyEmail('unknown-token')
+
+      expect(result).toBe('not_found')
+    })
+
+    it('returns "error" on unexpected API failure', async () => {
+      getMock.mockRejectedValue({ response: { status: 500 } })
+
+      const { verifyEmail } = useEmailVerification()
+      const result = await verifyEmail('bad-token')
+
+      expect(result).toBe('error')
+    })
+
+    it('calls GET verify-email with URL-encoded token', async () => {
+      getMock.mockResolvedValue(undefined)
+
+      const { verifyEmail } = useEmailVerification()
+      await verifyEmail('tok en+test')
+
+      expect(getMock).toHaveBeenCalledWith('verify-email?token=tok%20en%2Btest')
+    })
+  })
+
+  describe('resendVerificationEmail', () => {
+    it('calls POST verify-email/resend', async () => {
+      postMock.mockResolvedValue(undefined)
+
+      const { resendVerificationEmail } = useEmailVerification()
+      await resendVerificationEmail()
+
+      expect(postMock).toHaveBeenCalledWith('verify-email/resend', undefined)
+    })
+
+    it('calls onSuccess when POST succeeds', async () => {
+      postMock.mockResolvedValue(undefined)
+      const onSuccess = vi.fn()
+
+      const { resendVerificationEmail } = useEmailVerification()
+      await resendVerificationEmail(onSuccess)
+
+      expect(onSuccess).toHaveBeenCalledTimes(1)
+    })
+
+    it('calls onError when POST fails', async () => {
+      const networkError = new Error('network')
+      postMock.mockRejectedValue(networkError)
+      const onError = vi.fn()
+
+      const { resendVerificationEmail } = useEmailVerification()
+      await resendVerificationEmail(undefined, onError)
+
+      expect(onError).toHaveBeenCalledTimes(1)
+    })
+
+    it('starts cooldown after successful resend', async () => {
+      postMock.mockResolvedValue(undefined)
+      vi.useFakeTimers()
+
+      const { resendVerificationEmail, isResendOnCooldown, resendCooldown } = useEmailVerification()
+      await resendVerificationEmail()
+
+      expect(isResendOnCooldown.value).toBe(true)
+      expect(resendCooldown.value).toBe(60)
+
+      vi.advanceTimersByTime(60_000)
+      expect(resendCooldown.value).toBe(0)
+      expect(isResendOnCooldown.value).toBe(false)
+
+      vi.useRealTimers()
+    })
+  })
+})

--- a/docs/agents/instructions/backend.instructions.md
+++ b/docs/agents/instructions/backend.instructions.md
@@ -31,6 +31,21 @@ Guidelines to follow whenever working on any of the three backend layers: `domai
 - Mapping between domain objects and DTOs happens in the application layer (controllers, mappers).
 - Mapping between domain objects and entities happens in the infrastructure layer (adapters).
 
+### 1.4 Input Length Validation (Mandatory)
+
+Every text field in a request DTO **must** carry a `@Size` (or `@Length`) constraint. Use the reference table below. If a field type is not listed, pick the nearest equivalent and document the choice.
+
+| Field type | Constraint |
+|---|---|
+| Username | `@Size(min = 1, max = 100)` |
+| Password | `@Size(min = 1, max = 100)` |
+| Email | `@Size(max = 255)` |
+| Label (booklet, transaction, tag, …) | `@Size(min = 1, max = 100)` |
+| Description / free-text note | `@Size(max = 500)` |
+| Version string (e.g. TOS) | `@Size(max = 20)` |
+
+> **Checklist at the end of every backend task** — for each new or modified request DTO, verify that every `String` field has an explicit `@Size` bound. A missing constraint is a defect.
+
 ---
 
 > **Development workflow (TDD, SOLID, duplication, design patterns)** is defined in the cross-cutting file  

--- a/docs/agents/instructions/frontend.instructions.md
+++ b/docs/agents/instructions/frontend.instructions.md
@@ -65,6 +65,23 @@ client/
 
 ---
 
+## Input Length Limits (Mandatory)
+
+Every text input (`<InputText>`, `<Textarea>`, `<input>`, or equivalent PrimeVue component) **must** carry a `maxlength` attribute (or `:maxlength` binding). Use the reference table below — it mirrors the backend `@Size` constraints so the two layers stay in sync.
+
+| Field type | `maxlength` |
+|---|---|
+| Username | `100` |
+| Password | `100` |
+| Email | `255` |
+| Label (booklet, transaction, tag, …) | `100` |
+| Description / free-text note | `500` |
+| Version string (e.g. TOS) | `20` |
+
+> **Checklist at the end of every frontend task** — for each new or modified text input, verify that `maxlength` is set and matches the corresponding backend DTO constraint. A missing limit is a defect.
+
+---
+
 ## Component Duplication Policy
 
 > Before creating any new UI element, always check whether an existing component already covers the need.

--- a/docs/features/email-verification/application_email-verification.md
+++ b/docs/features/email-verification/application_email-verification.md
@@ -1,52 +1,53 @@
 # Application Module — Email Verification
 
 **Context**
-Expose the verification endpoints, surface the verified state to the frontend, and wire the flag-gated
-registration branching through the existing buses. The link in the emails lands on the client, which calls the
-verify endpoint with the token.
+Expose the verification endpoints publicly and surface `emailVerified` on the authenticated user
+payload so the client can render the appropriate UI. No feature flag involved — endpoints are always
+active. The verification link in the email lands on the client page, which calls the API with the token.
 
 **Scope (application)**
-- `POST /verify-email` (token in body or query) → consumes the token via `VerifyEmailUseCase`; returns success,
-  expired, or not-found outcomes mapped to appropriate status codes.
-- `POST /verify-email/resend` (authenticated) → `ResendVerificationEmailUseCase`.
-- Surface `emailVerified` on the authenticated user payload (session/refresh response and/or a `/me` settings
-  endpoint) so the client can render the unverified banner and settings indicator.
-- Wire `RegisterUserService` flag-gated behaviour through the command bus (no behavioural logic in the controller).
+- `GET /verify-email?token={token}` (public, no auth) — delegates to `VerifyEmailUseCase`;
+  returns 200 on success, 410 Gone on expiry, 404 on unknown token.
+- `POST /verify-email/resend` (authenticated) — delegates to `ResendVerificationEmailUseCase`;
+  returns 200, or 409 Conflict if already verified.
+- Add `emailVerified: Boolean` to the authenticated user payload (the response returned by `/me`,
+  session, and refresh endpoints) so the client always has the current state.
+- No business logic in controllers — all branching lives in the use cases.
 
 **Acceptance Criteria**
 Feature: Email verification API
   In order to let users confirm their email
   As a client
-  I want endpoints to verify and resend, and verified state in the user payload
+  I want public verification and authenticated resend endpoints, and verified state in the user payload
 
-Scenario: Verify with a valid token
+Scenario: Valid token is accepted
   Given a valid, unexpired verification token
-  When the client calls POST /verify-email with that token
+  When the client calls GET /verify-email?token=<valid>
   Then the response is 200
   And the user's emailVerified becomes true
 
-Scenario: Verify with an expired token
+Scenario: Expired token returns 410
   Given an expired verification token
-  When the client calls POST /verify-email with that token
-  Then the response is a 4xx error indicating the link expired
+  When the client calls GET /verify-email?token=<expired>
+  Then the response is 410 Gone
 
-Scenario: Verify with an unknown token
-  Given a token matching no record
-  When the client calls POST /verify-email with that token
+Scenario: Unknown token returns 404
+  Given a token value matching no record
+  When the client calls GET /verify-email?token=<unknown>
   Then the response is 404
 
-Scenario: Resend verification email
+Scenario: Resend dispatches a new verification email
   Given an authenticated user with emailVerified = false
-  When the user calls POST /verify-email/resend
+  When the client calls POST /verify-email/resend
   Then the response is 200
   And a new verification email is dispatched
 
-Scenario: Verified state is exposed to the client
-  Given an authenticated user
-  When the client fetches the user/session payload
-  Then the payload includes emailVerified
-
 Scenario: Resend is rejected for a verified user
   Given an authenticated user with emailVerified = true
-  When the user calls POST /verify-email/resend
-  Then the response is a 4xx error
+  When the client calls POST /verify-email/resend
+  Then the response is 409 Conflict
+
+Scenario: emailVerified is exposed in the user payload
+  Given an authenticated user
+  When the client calls the session or /me endpoint
+  Then the response body includes emailVerified as a boolean

--- a/docs/features/email-verification/client_email-verification.md
+++ b/docs/features/email-verification/client_email-verification.md
@@ -1,56 +1,78 @@
 # Client Module — Email Verification
 
 **Context**
-Frontend surfaces for the inaugural feature flag, all gated by `useFeatureFlags().isEnabled("email-verification")`.
-The verification email link lands on a client page that confirms the token; for unverified simple users the app
-shows a clear header banner and a settings indicator. Beta testers are auto-confirmed by following their access
-link, so no banner is expected for them once confirmed.
+The frontend surfaces the unverified state in two places: a warning indicator on the "Paramètres" tab
+(visible on every authenticated page), and a dedicated section inside the settings page. A separate
+`/verify-email` page handles the landing from the email link.
+
+Admin-created users have `emailVerified = true` from day one and never see any of these surfaces.
+Only self-registered users with `emailVerified = false` are affected.
 
 **Scope (client)**
-- A `verify-email` page reading the `token` query param, calling `POST /verify-email`, and showing success /
-  expired / error states with a path forward (e.g. resend).
-- A header banner in `NHeader.vue` shown when the flag is enabled and `emailVerified === false`, clearly stating
-  the email is not verified, with a resend/confirm action.
-- A settings-page indicator showing verification status and a resend button.
-- All of the above hidden entirely when the `email-verification` flag is disabled.
+- **Paramètres tab indicator** — when `emailVerified === false`, the "Paramètres" navigation tab shows
+  a warning badge or icon. Hovering it displays a tooltip: *"Votre compte doit être vérifié"*.
+  Disappears once `emailVerified` becomes `true`.
+- **Settings page section** — a visible block inside the settings page when `emailVerified === false`:
+  - Displays the user's email address.
+  - Clear message that the address is not yet verified.
+  - A *"Vérifier mon e-mail"* button that calls `POST /verify-email/resend` and shows feedback
+    (success toast / error state).
+  - Hidden entirely when `emailVerified === true`.
+- **`/verify-email` page** — public route, reads the `token` query param, calls
+  `GET /verify-email?token=...`, and renders:
+  - **Success**: confirmation message, link to log in or go to the dashboard.
+  - **Expired link**: error message with a *"Renvoyer un e-mail"* button calling resend (if authenticated)
+    or a note to log in first.
+  - **Unknown/invalid**: generic error message.
+- Refresh the `emailVerified` state in the composable / store after a successful verification so all
+  indicators update immediately without a full reload.
 
 **Acceptance Criteria**
 Feature: Email verification UI
   In order to know and fix my unverified status
-  As a user
-  I want clear banners, a settings indicator, and a verification landing page
+  As a self-registered user
+  I want a tab indicator, a settings section, and a verification landing page
 
-Scenario: Verification landing succeeds
-  Given the flag "email-verification" is enabled
-  And the user opens /verify-email?token=<valid>
-  When the page calls the verify endpoint and it succeeds
-  Then the user sees a confirmation message
-  And the unverified banner no longer appears
+Scenario: Paramètres tab shows warning badge for unverified user
+  Given an authenticated user with emailVerified = false
+  When any authenticated page renders
+  Then the "Paramètres" tab displays a warning indicator
+  And hovering it shows the tooltip "Votre compte doit être vérifié"
 
-Scenario: Verification landing with an expired token
+Scenario: No warning badge when email is verified
+  Given an authenticated user with emailVerified = true
+  When any authenticated page renders
+  Then the "Paramètres" tab shows no warning indicator
+
+Scenario: Settings section shows email and resend button when unverified
+  Given an authenticated user with emailVerified = false
+  When the user opens the settings page
+  Then a section shows the user's email address with an "not verified" indication
+  And a "Vérifier mon e-mail" button is visible
+
+Scenario: Settings section is hidden when email is verified
+  Given an authenticated user with emailVerified = true
+  When the user opens the settings page
+  Then no unverified email section is rendered
+
+Scenario: Resend button dispatches a new email and shows feedback
+  Given an authenticated user with emailVerified = false on the settings page
+  When the user clicks "Vérifier mon e-mail"
+  Then POST /verify-email/resend is called
+  And a success toast confirms the email was sent
+
+Scenario: Verification landing — success
+  Given the user opens /verify-email?token=<valid>
+  When the page calls GET /verify-email?token=<valid> and receives 200
+  Then a confirmation message is displayed
+  And the emailVerified state is refreshed in the app
+
+Scenario: Verification landing — expired link
   Given the user opens /verify-email?token=<expired>
-  When the verify call returns an expired error
-  Then the page shows an "link expired" message with a resend option
+  When the page calls GET /verify-email?token=<expired> and receives 410
+  Then the page shows "lien expiré" with an option to resend or log in first
 
-Scenario: Header banner for an unverified simple user
-  Given the flag "email-verification" is enabled
-  And the authenticated user has emailVerified = false
-  When any authenticated page renders
-  Then a clear "email not verified" banner is shown in the header
-
-Scenario: No banner when email is verified
-  Given the authenticated user has emailVerified = true
-  When any authenticated page renders
-  Then no unverified banner is shown
-
-Scenario: Settings shows verification status and resend
-  Given the flag "email-verification" is enabled
-  And the user has emailVerified = false
-  When the user opens their settings
-  Then the settings clearly indicate the email is not verified
-  And a resend button is available
-
-Scenario: All UI hidden when the flag is disabled
-  Given the flag "email-verification" is disabled
-  When authenticated pages and settings render
-  Then no verification banner, indicator, or landing behaviour is active
+Scenario: Verification landing — unknown token
+  Given the user opens /verify-email?token=<unknown>
+  When the page calls GET /verify-email?token=<unknown> and receives 404
+  Then the page shows a generic error message

--- a/docs/features/email-verification/domain_email-verification.md
+++ b/docs/features/email-verification/domain_email-verification.md
@@ -1,88 +1,76 @@
 # Domain Module — Email Verification
 
 **Context**
-Inaugural use of the feature-flag system: gate email verification behind the global flag `email-verification`.
-The verification flow differs by the user's `SubscriptionPlan` (the per-plan decision lives here in the domain,
-since flags are global ON/OFF):
+Self-registered users must verify their email address before gaining full trust. Users created directly
+by an admin (beta testers) are considered implicitly verified — the admin vouches for the address.
+The domain models the verification token lifecycle, adapts the registration and admin-creation flows,
+and exposes two use cases: token consumption and resend.
 
-- **BETA_TESTER** — receives an *access* email containing a link. Clicking the link is treated as proof the
-  user owns a real mailbox, so following it **auto-confirms** their email.
-- **Simple user (FREE)** — gated by a **sub-flag** `email-verification-simple-user-registration` because there
-  is no settled registration strategy yet. When the sub-flag is on, a public registration is created with the
-  **FREE** plan instead of `BETA_TESTER`, a *verification* email is sent, the user can still log in, but their
-  email is flagged as **not verified** until they confirm it. When the sub-flag is off, registration keeps
-  assigning `BETA_TESTER` (today's behaviour).
-
-When `email-verification` is **off**, registration behaves exactly as today (welcome email only, no verified
-state surfaced).
+No feature flag is involved — the verification flow is always active.
 
 **Scope (domain)**
-- `User` gains `emailVerified: Boolean` (default `false`).
-- `EmailVerificationToken` model: token value, owning `UserId`, expiry — created via injected `Clock`/`IdGenerator`
-  (no `LocalDateTime.now()` / `UUID.randomUUID()` in domain).
-- Output ports: `EmailVerificationTokenRepository` (save, findByToken, deleteByUserId); extend the notification
-  port to send an *access-confirmation* email (beta) and a *verification* email (simple user), each carrying the link.
+- `User` gains `emailVerified: Boolean`.
+  - Admin-created users (`CreateAdminIfNotExists`, admin user-creation) → `emailVerified = true`.
+  - Self-registered users (`RegisterUserService`) → `emailVerified = false`; a token is generated and
+    a verification email is dispatched immediately after account creation.
+- `EmailVerificationToken` value object: secure token string, owning `UserId`, `expiresAt` — created
+  via injected `Clock` and `IdGenerator` (no `LocalDateTime.now()` / `UUID.randomUUID()` in domain).
+- Output ports:
+  - `EmailVerificationTokenRepository` — `save`, `findByToken`, `deleteByUserId`.
+  - Extend `NotificationPort` with `sendVerificationEmail(to, token, verificationLink)`.
 - Use cases:
-  - `VerifyEmailUseCase` — consumes a token, sets `emailVerified = true`, rejects expired/unknown tokens.
-  - `ResendVerificationEmailUseCase` — re-issues a token + email for an unverified user.
-- `RegisterUserService` branches on `IsFeatureEnabledUseCase("email-verification")` and the sub-flag to decide
-  the assigned `SubscriptionPlan` (FREE when the sub-flag is on, else BETA_TESTER), the initial `emailVerified`
-  state, and which email to send.
+  - `VerifyEmailUseCase` — accepts a raw token string, resolves the token, checks expiry, marks
+    `emailVerified = true` on the owner, then deletes all tokens for that user.
+  - `ResendVerificationEmailUseCase` — rejects already-verified users; deletes any existing token,
+    issues a fresh one, and dispatches a new verification email.
 
 **Acceptance Criteria**
 Feature: Email verification
-  In order to confirm users own a real mailbox
+  In order to confirm that registered users own a real mailbox
   As the system
-  I want flag-gated email verification that adapts to the subscription plan
+  I want to issue and consume verification tokens on self-registration
 
-Scenario: Flag off keeps current registration behaviour
-  Given the flag "email-verification" is disabled
-  When a user registers
-  Then no verification or access-confirmation email logic runs
-  And the welcome email is sent as before
+Scenario: Self-registered user gets emailVerified = false and receives a verification email
+  Given a visitor completes the registration form
+  When RegisterUserService creates the account
+  Then the user is persisted with emailVerified = false
+  And a verification token is saved
+  And a verification email is dispatched via NotificationPort
 
-Scenario: Beta tester link auto-confirms email
-  Given the flag "email-verification" is enabled
-  And a BETA_TESTER user has received an access email with a valid token
-  When the user follows the access link and VerifyEmailUseCase consumes the token
-  Then the user's emailVerified becomes true
+Scenario: Admin-created user is auto-verified
+  Given an admin creates a user through the admin user-creation flow
+  When the user is persisted
+  Then emailVerified = true
+  And no verification token is issued
+  And no verification email is sent
 
-Scenario: Sub-flag on assigns FREE and sends a verification email
-  Given the flag "email-verification" is enabled
-  And the sub-flag "email-verification-simple-user-registration" is enabled
-  When a visitor registers
-  Then the user is created with subscriptionPlan = FREE
-  And emailVerified = false
-  And a verification email with a token is sent
-  And the user can still authenticate
-
-Scenario: Sub-flag off keeps BETA_TESTER assignment
-  Given the flag "email-verification" is enabled
-  And the sub-flag "email-verification-simple-user-registration" is disabled
-  When a visitor registers
-  Then the user is created with subscriptionPlan = BETA_TESTER
-  And the beta access-confirmation email is sent
-  And no simple-user verification email is sent
+Scenario: Valid token is consumed and email is marked verified
+  Given a self-registered user with emailVerified = false
+  And a valid, unexpired token exists for that user
+  When VerifyEmailUseCase consumes the token
+  Then emailVerified becomes true
+  And all tokens for that user are deleted
 
 Scenario: Expired token is rejected
-  Given an email verification token whose expiry is in the past
+  Given a verification token whose expiresAt is in the past
   When VerifyEmailUseCase consumes it
-  Then the system returns a failure
+  Then the system returns an EXPIRED failure
   And emailVerified remains false
 
 Scenario: Unknown token is rejected
-  Given a token value that matches no stored token
+  Given a token string that matches no stored token
   When VerifyEmailUseCase consumes it
-  Then the system returns a not-found failure
+  Then the system returns a NOT_FOUND failure
 
 Scenario: Resend issues a fresh token for an unverified user
   Given an authenticated user with emailVerified = false
-  When the user requests a verification email resend
-  Then a new token is persisted
-  And a verification email is sent
+  When ResendVerificationEmailUseCase is invoked
+  Then any existing token for that user is deleted
+  And a new token is saved
+  And a verification email is dispatched
 
 Scenario: Resend is rejected for an already-verified user
   Given an authenticated user with emailVerified = true
-  When the user requests a verification email resend
-  Then the system returns a failure
-  And no new token is created
+  When ResendVerificationEmailUseCase is invoked
+  Then the system returns an ALREADY_VERIFIED failure
+  And no token is created or email sent

--- a/docs/features/email-verification/infrastructure_email-verification.md
+++ b/docs/features/email-verification/infrastructure_email-verification.md
@@ -1,52 +1,51 @@
 # Infrastructure Module — Email Verification
 
 **Context**
-Persist the new verified state and verification tokens, and extend the Spring mail adapter to send the two new
-email types with a link carrying the token. Mirrors the existing `SpringMailNotificationAdapter` /
-`EmailTemplates` approach and reuses the configured `app.url`.
+Persist the `emailVerified` state on the user table, store and retrieve verification tokens, and extend
+the Spring mail adapter with a new verification email template. Mirrors the existing
+`SpringMailNotificationAdapter` / `EmailTemplates` pattern.
 
 **Scope (infrastructure)**
-- `emailVerified` column added to the user table, default `false`. Existing rows are **not** backfilled to
-  `true` — every current account starts unverified and must confirm through the flow once the flag is enabled.
+- Flyway migration: add `email_verified BOOLEAN NOT NULL DEFAULT FALSE` to the users table.
+  Existing rows are **not** backfilled to `true` — every current account starts unverified.
 
-> **TODO (future)**: when `email-verification` is first turned ON in production, every existing user will see
-> the unverified banner and need to re-confirm. A one-off re-notification job (e.g. "send access/verification
-> email to all users with `emailVerified = false`") will be needed before flipping the flag in prod. Out of
-> scope for this issue — create a dedicated operational task when the flag is ready to be enabled.
-- `EmailVerificationTokenEntity` + JPA adapter implementing `EmailVerificationTokenRepository`
-  (save, findByToken, deleteByUserId); token TTL configurable.
-- Token generation via the infrastructure `IdGenerator`/secure random adapter.
-- `NotificationPort` extension implemented: `sendAccessConfirmationEmail(...)` (beta — link confirms on click)
-  and `sendEmailVerificationEmail(...)` (simple user), each building a link as `${app.url}/verify-email?token=...`.
-- New `EmailTemplates` entries for the access-confirmation and verification emails.
+  > **Operational note (future)**: when the system is deployed with this migration, all existing
+  > beta-tester accounts will show `emailVerified = false`. A one-off admin action or data-patch
+  > script will be needed to backfill those rows to `true` before the UI surfaces the unverified state.
+  > Out of scope for this issue.
+
+- `EmailVerificationTokenEntity` mapped to a new `email_verification_tokens` table
+  (columns: `token`, `user_id`, `expires_at`).
+- `JpaEmailVerificationTokenRepository` implementing the domain port
+  (`save`, `findByToken`, `deleteByUserId`).
+- Token TTL configurable via `app.email-verification.token-ttl` (default 24 h).
+- Secure token generation: delegate to the existing infrastructure `IdGenerator` or a
+  `SecureRandom`-based adapter — no plain UUIDs.
+- `SpringMailNotificationAdapter` extended with `sendVerificationEmail(to, token, verificationLink)`,
+  using a new `EmailTemplates.VERIFICATION` entry.
 
 **Acceptance Criteria**
-Feature: Email verification persistence and delivery
+Feature: Email verification — persistence and delivery
   In order to verify mailboxes
   As the system
-  I want verified state, tokens, and emails persisted and delivered
+  I want verified state, tokens, and emails persisted and delivered correctly
 
-Scenario: Persist and look up a verification token
-  Given the token adapter
+Scenario: Token is saved and can be retrieved by value
+  Given the JPA token repository
   When a token is saved for a user
-  Then it can be retrieved by its token value with the correct owner and expiry
+  Then it can be retrieved by its token string with the correct userId and expiresAt
 
-Scenario: Verified state survives a round-trip
+Scenario: All tokens for a user are deleted
+  Given two tokens saved for the same userId
+  When deleteByUserId is called
+  Then no tokens remain for that user
+
+Scenario: emailVerified survives a round-trip
   Given a user persisted with emailVerified = false
-  When the user is updated to emailVerified = true
-  Then reloading the user reports emailVerified = true
+  When the user is updated to emailVerified = true and reloaded
+  Then the persisted value is true
 
-Scenario: Verification email contains the token link
-  Given the flag-gated simple-user flow triggers a verification email
-  When the mail adapter sends it
-  Then the email body contains a link to ${app.url}/verify-email with the generated token
-
-Scenario: Access-confirmation email is sent for beta testers
-  Given a BETA_TESTER registration under the enabled flag
-  When the mail adapter sends the access email
-  Then the body contains an access link carrying the verification token
-
-Scenario: Tokens are cleared after successful verification
-  Given a user verifies their email
-  When verification succeeds
-  Then their outstanding verification tokens are removed
+Scenario: Verification email contains the correct link
+  Given the mail adapter is invoked with a token "abc123" and verificationLink "https://app/verify-email?token=abc123"
+  When the email is sent
+  Then the email body contains "https://app/verify-email?token=abc123"

--- a/docs/technical/email-verification/2026-05-31-application-email-verification.md
+++ b/docs/technical/email-verification/2026-05-31-application-email-verification.md
@@ -1,0 +1,86 @@
+# Email Verification — Application Layer
+
+> **Topic**: REST endpoints + security wiring + user payload
+> **Date**: 2026-05-31
+> **Author**: Technical Backend
+
+---
+
+## Context
+
+The domain use cases `VerifyEmailUseCase` and `ResendVerificationEmailUseCase` are wired. This report covers exposing them via REST, mapping the two new `ResultState` values to the correct HTTP codes (410 Gone, 409 Conflict), opening the public verify endpoint in `SecurityConfig`, and surfacing `emailVerified` on the authenticated user status payload.
+
+## Current State
+
+- `SessionController` at `api/user/**` handles login, logout, refresh, consent, settings.
+- `toHttpResponse()` in `ApiMappingExtensions.kt` maps `ResultState` to HTTP exceptions — it does not yet handle `EMAIL_VERIFICATION_TOKEN_EXPIRED` or `EMAIL_ALREADY_VERIFIED`.
+- `GET /api/user/me` returns `UserStatusDTO(consentRequired)` via `HasUserConsentedQuery`.
+- `SecurityConfig` has an explicit allowlist; any new public endpoint must be explicitly permitted.
+- No `GoneException` (410) exists yet — only `NotFoundException` (404) and `ConflictException` (409).
+
+## Analysis
+
+### HTTP status mapping
+
+| Domain `ResultState` | HTTP code | Rationale |
+|---|---|---|
+| `EMAIL_VERIFICATION_TOKEN_EXPIRED` | 410 Gone | The resource (token) existed but is permanently expired — 410 is semantically correct and lets the client distinguish expiry from "never existed" |
+| `EMAIL_ALREADY_VERIFIED` | 409 Conflict | A business invariant conflict: resending to an already-verified address |
+
+### Public endpoint — security concern
+
+`GET /api/verify-email?token=` must be public (no auth cookie required — the user may not be logged in when they click the email link). Adding it to the `permitAll` list in `SecurityConfig` is the only required change. The endpoint accepts a query param — no request body to validate, so no CSRF concern (GET is read-only in HTTP semantics even though it mutates state here; the token acts as the CSRF protection itself).
+
+### Surfacing `emailVerified` on `/me`
+
+`GET /api/user/me` calls `HasUserConsentedQuery` which loads the user and returns `Boolean`. Adding a second query `GetUserEmailVerifiedQuery` keeps the domain interface focused and avoids changing existing use case contracts. Two queries = two DB reads, but `/me` is not a hot-path endpoint — acceptable.
+
+### Controller placement
+
+The two new endpoints belong in a dedicated `EmailVerificationController` rather than `SessionController` to respect SRP: session lifecycle vs. email verification lifecycle are different concerns.
+
+## Recommended Approach
+
+```kotlin
+// GET /api/verify-email?token=  →  200 / 410 / 404
+// POST /api/verify-email/resend →  200 / 409
+@RestController
+@RequestMapping("api/verify-email")
+class EmailVerificationController(private val commandBus: CommandBus) {
+
+    @GetMapping
+    fun verify(@RequestParam token: String): ResponseEntity<Void> =
+        commandBus.dispatch(VerifyEmailCommand(token))
+            .map { null as Void? }
+            .toHttpResponse()
+
+    @PostMapping("/resend")
+    fun resend(): ResponseEntity<Void> =
+        commandBus.dispatch(ResendVerificationEmailCommand(UserId(currentUser.id)))
+            .map { null as Void? }
+            .toHttpResponse()
+}
+```
+
+## Implementation Notes
+
+1. `GoneException` — new exception class in `Exception.kt`
+2. `ProblemDetailHandler` — add `@ExceptionHandler(GoneException::class)` → 410
+3. `ApiMappingExtensions.toHttpResponse()` — add `EMAIL_VERIFICATION_TOKEN_EXPIRED → GoneException`, `EMAIL_ALREADY_VERIFIED → ConflictException`
+4. `SecurityConfig` — add `authorize("/api/verify-email", permitAll)`
+5. Domain: add thin `GetUserEmailVerifiedQuery` + service (minimal, follows `HasUserConsentedUseCase` pattern)
+6. `UserStatusDTO` — add `emailVerified: Boolean`
+7. `SessionController.getUserStatus()` — call both queries, combine into `UserStatusDTO`
+8. `EmailVerificationController` — new file
+
+## Trade-offs & Risks
+
+| Concern | Impact | Mitigation |
+|---|---|---|
+| Two DB reads in `/me` | Low | `/me` is lightweight; not a hot path |
+| GET endpoint mutating state | Low | Industry standard for email verification links; token is the anti-CSRF mechanism |
+| 410 vs 400 for expired token | Low | 410 is semantically correct and enables the client to distinguish cases cleanly |
+
+## References
+- [RFC 7231 §6.5.9 — 410 Gone](https://www.rfc-editor.org/rfc/rfc7231#section-6.5.9)
+- [Spring Security `permitAll` vs `anonymous`](https://docs.spring.io/spring-security/reference/servlet/authorization/authorize-http-requests.html)

--- a/docs/technical/email-verification/2026-05-31-infrastructure-email-verification.md
+++ b/docs/technical/email-verification/2026-05-31-infrastructure-email-verification.md
@@ -1,0 +1,103 @@
+# Email Verification — Infrastructure Layer
+
+> **Topic**: Infrastructure adapters for email verification
+> **Date**: 2026-05-31
+> **Author**: Technical Backend
+
+---
+
+## Context
+
+The domain layer now defines `EmailVerificationTokenRepository`, `SecureTokenGenerator`, `NotificationPort.sendVerificationEmail`, and `UserRepository.markEmailVerified`. This report covers the infrastructure implementation: schema migration, JPA entity/adapter, secure token generation, and Spring Mail extension.
+
+## Current State
+
+- `user_resource` table has no `email_verified` column. Existing rows are unverified by default.
+- `SpringMailNotificationAdapter` implements `NotificationPort` with `sendWelcomeEmail` only.
+- `EmailTemplates` is an internal `object` with a shared `baseLayout`.
+- `HexagonInjectionConfiguration` component-scans `@DomainService` classes — domain services with non-bean constructor args (e.g. `Clock`, `Duration`) must be declared explicitly as `@Bean`.
+
+## Analysis
+
+### Schema
+
+Two DDL changes needed in a single migration:
+1. `ALTER TABLE user_resource ADD COLUMN email_verified BOOLEAN NOT NULL DEFAULT FALSE` — safe zero-downtime; existing rows default to `false`.
+2. `CREATE TABLE email_verification_token` with `ON DELETE CASCADE` on the FK to `user_resource.id_user` — ensures tokens are cleaned up when a user is deleted without requiring explicit domain logic.
+
+### Token entity
+
+No surrogate UUID needed: the token value is already unique and immutable (32-byte base64url = 43 chars, stored as `VARCHAR(64)` with a `PRIMARY KEY` constraint). No JPA `@OneToMany` on `UserResource` — token lifecycle is managed exclusively via `EmailVerificationTokenRepository`.
+
+### SecureTokenGenerator
+
+`SecureRandom` with `Base64.getUrlEncoder().withoutPadding()` over 32 bytes produces a 43-char URL-safe string. No dependency beyond the JDK; no additional library needed.
+
+### Spring wiring — `EmailVerificationIssuer`
+
+`EmailVerificationIssuer` is annotated `@DomainService` which is picked up by the component-scan filter in `HexagonInjectionConfiguration`. However, it requires `Clock` (not a default Spring bean) and `Duration` (a plain value). If left to component scan, Spring will fail to auto-wire. **Resolution**: remove `@DomainService` from `EmailVerificationIssuer` and declare it explicitly as `@Bean` in `EmailVerificationConfiguration`, following the same pattern used for `TokenGenerator`.
+
+`VerifyEmailService` also needs `Clock` — solved by declaring a `@Bean fun systemClock(): Clock = Clock.systemUTC()` in `EmailVerificationConfiguration`.
+
+### TTL configuration
+
+Exposed via `app.email-verification.token-ttl` (ISO-8601 duration, e.g. `PT24H`). Bound with `@ConfigurationProperties`. Registered in `JpaAutoConfiguration` alongside `RetentionProperties`.
+
+## Recommended Approach
+
+```kotlin
+// EmailVerificationProperties.kt
+@ConfigurationProperties(prefix = "app.email-verification")
+data class EmailVerificationProperties(
+    val tokenTtl: Duration = Duration.ofHours(24),
+)
+
+// EmailVerificationConfiguration.kt
+@Configuration
+@EnableConfigurationProperties(EmailVerificationProperties::class)
+class EmailVerificationConfiguration {
+    @Bean fun systemClock(): Clock = Clock.systemUTC()
+
+    @Bean fun emailVerificationIssuer(
+        tokenRepo: EmailVerificationTokenRepository,
+        generator: SecureTokenGenerator,
+        notification: NotificationPort,
+        clock: Clock,
+        props: EmailVerificationProperties,
+    ): EmailVerificationIssuer = EmailVerificationIssuer(tokenRepo, generator, notification, clock, props.tokenTtl)
+}
+```
+
+### Why this approach
+- Keeps `EmailVerificationIssuer` a pure Kotlin class (no Spring annotations in domain).
+- Explicit `@Bean` mirrors the existing `tokenGenerator` pattern in `HexagonInjectionConfiguration`.
+- `Clock.systemUTC()` is a well-known, testable abstraction — tests override it via constructor injection.
+
+## Implementation Notes
+
+1. Flyway `V27__add_email_verification.sql`
+2. `UserResource` — add `emailVerified: Boolean = false` field
+3. `UserRepositoryJpaAdapter` — update `register()` + add `markEmailVerified()`
+4. `DatasourceMapper` — add `emailVerified` to `toModel()` and `toModelWithPasswords()`
+5. `EmailVerificationTokenEntity` + `EmailVerificationTokenJpaRepository` (new)
+6. `EmailVerificationTokenRepositoryJpaAdapter` (new)
+7. `SecureTokenGeneratorAdapter` (new)
+8. `EmailTemplates.verificationEmail()` (new template function)
+9. `SpringMailNotificationAdapter.sendVerificationEmail()` (new method)
+10. `EmailVerificationProperties` + `EmailVerificationConfiguration` (new)
+11. Remove `@DomainService` from domain's `EmailVerificationIssuer`
+12. `JpaAutoConfiguration` — register `EmailVerificationProperties`
+13. Integration test `EmailVerificationTokenRepositoryJpaAdapterIT`
+
+## Trade-offs & Risks
+
+| Concern | Impact | Mitigation |
+|---|---|---|
+| Existing users start with `emailVerified = false` | Medium — users see "unverified" banner on first login after deploy | Backfill script to set existing users to `true` before enabling UI |
+| Token table grows unbounded if tokens expire but verification never completes | Low | Future: scheduled cleanup job for expired rows; `expiresAt` index helps queries |
+| `@Async` mail sending — failure is silent (logged only) | Low | Consistent with existing welcome-email behaviour; structured logging in place |
+
+## References
+- [Spring Boot `@ConfigurationProperties`](https://docs.spring.io/spring-boot/docs/current/reference/html/configuration-metadata.html)
+- [java.security.SecureRandom](https://docs.oracle.com/en/java/docs/api/java.base/java/security/SecureRandom.html)
+- [Flyway zero-downtime migrations](https://flywaydb.org/documentation/concepts/migrations)

--- a/domain/src/main/kotlin/fr/sacane/jmanager/domain/models/EmailVerificationToken.kt
+++ b/domain/src/main/kotlin/fr/sacane/jmanager/domain/models/EmailVerificationToken.kt
@@ -1,0 +1,11 @@
+package fr.sacane.jmanager.domain.models
+
+import java.time.LocalDateTime
+
+data class EmailVerificationToken(
+    val token: String,
+    val userId: UserId,
+    val expiresAt: LocalDateTime,
+) {
+    fun isExpired(now: LocalDateTime): Boolean = expiresAt.isBefore(now)
+}

--- a/domain/src/main/kotlin/fr/sacane/jmanager/domain/models/User.kt
+++ b/domain/src/main/kotlin/fr/sacane/jmanager/domain/models/User.kt
@@ -38,6 +38,7 @@ class User(
     var projectionWindowDays: Int = 15,
     val subscriptionPlan: SubscriptionPlan = SubscriptionPlan.BETA_TESTER,
     var consent: ConsentRecord? = null,
+    var emailVerified: Boolean = false,
 ) {
 
     init {

--- a/domain/src/main/kotlin/fr/sacane/jmanager/domain/port/input/admin/AdminCreateUserUseCase.kt
+++ b/domain/src/main/kotlin/fr/sacane/jmanager/domain/port/input/admin/AdminCreateUserUseCase.kt
@@ -1,0 +1,60 @@
+package fr.sacane.jmanager.domain.port.input.admin
+
+import fr.sacane.jmanager.domain.hexadoc.DomainService
+import fr.sacane.jmanager.domain.hexadoc.Port
+import fr.sacane.jmanager.domain.hexadoc.Side
+import fr.sacane.jmanager.domain.models.SubscriptionPlan
+import fr.sacane.jmanager.domain.models.User
+import fr.sacane.jmanager.domain.port.input.Command
+import fr.sacane.jmanager.domain.port.input.CommandHandler
+import fr.sacane.jmanager.domain.port.output.Hasher
+import fr.sacane.jmanager.domain.port.output.NotificationPort
+import fr.sacane.jmanager.domain.port.output.UserRepository
+import fr.sacane.jmanager.domain.usecase.EmailVerificationIssuer
+import fr.sacane.jmanager.domain.utils.DomainError
+import fr.sacane.jmanager.domain.utils.Result
+import fr.sacane.jmanager.domain.utils.ResultState
+import fr.sacane.jmanager.domain.utils.failure
+import fr.sacane.jmanager.domain.utils.success
+
+data class AdminCreateUserCommand(
+    val username: String,
+    val password: String,
+    val email: String,
+) : Command<User>
+
+@Port(Side.APPLICATION)
+interface AdminCreateUserUseCase : CommandHandler<AdminCreateUserCommand, User> {
+    override val commandClass get() = AdminCreateUserCommand::class
+}
+
+@DomainService
+class AdminCreateUserService(
+    private val userRepository: UserRepository,
+    private val hasher: Hasher,
+    private val notificationPort: NotificationPort,
+    private val emailVerificationIssuer: EmailVerificationIssuer,
+) : AdminCreateUserUseCase {
+
+    override fun handle(command: AdminCreateUserCommand): Result<User> {
+        if (command.email.isBlank()) {
+            return failure(
+                ResultState.INVALID,
+                DomainError(ResultState.INVALID.code, "domain.user.admin.create.email_required", "L'email est obligatoire")
+            )
+        }
+        val hashedPassword = hasher.hash(command.password)
+        val user = userRepository.register(
+            username = command.username,
+            password = hashedPassword,
+            subscriptionPlan = SubscriptionPlan.BETA_TESTER,
+            email = command.email,
+        ) ?: return failure(
+            ResultState.INVALID,
+            DomainError(ResultState.INVALID.code, "domain.user.admin.create.failed", "Une erreur est survenue lors de la création de l'utilisateur")
+        )
+        val verificationToken = emailVerificationIssuer.issue(user.id)
+        notificationPort.sendWelcomeWithVerificationEmail(user.username, command.email, user.subscriptionPlan, verificationToken.token)
+        return success(user)
+    }
+}

--- a/domain/src/main/kotlin/fr/sacane/jmanager/domain/port/input/user/CreateAdminIfNotExistsUseCase.kt
+++ b/domain/src/main/kotlin/fr/sacane/jmanager/domain/port/input/user/CreateAdminIfNotExistsUseCase.kt
@@ -45,7 +45,7 @@ class CreateAdminIfNotExistsService(
                 )
             else success(existingAdmin.user)
         }
-        val adminUser = userRepository.register(command.username, hashedPassword, setOf(Role.USER, Role.ADMIN))
+        val adminUser = userRepository.register(command.username, hashedPassword, setOf(Role.USER, Role.ADMIN), emailVerified = true)
             ?: return failure(
                 ResultState.INVALID,
                 DomainError(ResultState.INVALID.code, "domain.user.admin.creation_failed", "Une erreur est survenue lors de la création de l'administrateur")

--- a/domain/src/main/kotlin/fr/sacane/jmanager/domain/port/input/user/GetUserEmailVerifiedUseCase.kt
+++ b/domain/src/main/kotlin/fr/sacane/jmanager/domain/port/input/user/GetUserEmailVerifiedUseCase.kt
@@ -1,0 +1,38 @@
+package fr.sacane.jmanager.domain.port.input.user
+
+import fr.sacane.jmanager.domain.hexadoc.DomainService
+import fr.sacane.jmanager.domain.hexadoc.Port
+import fr.sacane.jmanager.domain.hexadoc.Side
+import fr.sacane.jmanager.domain.models.UserId
+import fr.sacane.jmanager.domain.port.input.Query
+import fr.sacane.jmanager.domain.port.input.QueryHandler
+import fr.sacane.jmanager.domain.port.output.UserRepository
+import fr.sacane.jmanager.domain.utils.DomainError
+import fr.sacane.jmanager.domain.utils.Result
+import fr.sacane.jmanager.domain.utils.ResultState
+import fr.sacane.jmanager.domain.utils.failure
+import fr.sacane.jmanager.domain.utils.success
+
+data class EmailVerifiedStatus(val emailVerified: Boolean, val email: String?)
+
+data class GetUserEmailVerifiedQuery(val userId: UserId) : Query<EmailVerifiedStatus>
+
+@Port(Side.APPLICATION)
+interface GetUserEmailVerifiedUseCase : QueryHandler<GetUserEmailVerifiedQuery, EmailVerifiedStatus> {
+    override val queryClass get() = GetUserEmailVerifiedQuery::class
+}
+
+@DomainService
+class GetUserEmailVerifiedService(
+    private val userRepository: UserRepository,
+) : GetUserEmailVerifiedUseCase {
+
+    override fun handle(query: GetUserEmailVerifiedQuery): Result<EmailVerifiedStatus> {
+        val user = userRepository.findUserById(query.userId)
+            ?: return failure(
+                ResultState.USER_NOT_FOUND,
+                DomainError(ResultState.USER_NOT_FOUND.code, "domain.user.email_verification.user_not_found", "L'utilisateur est introuvable"),
+            )
+        return success(EmailVerifiedStatus(emailVerified = user.emailVerified, email = user.email))
+    }
+}

--- a/domain/src/main/kotlin/fr/sacane/jmanager/domain/port/input/user/RegisterUserUseCase.kt
+++ b/domain/src/main/kotlin/fr/sacane/jmanager/domain/port/input/user/RegisterUserUseCase.kt
@@ -73,7 +73,7 @@ class RegisterUserService(
         val userResult = userRepository.register(
             command.username, hashedPassword,
             email = command.email,
-            subscriptionPlan = SubscriptionPlan.BETA_TESTER,
+            subscriptionPlan = SubscriptionPlan.FREE,
             tosAcceptedAt = command.tosAcceptedAt,
             tosVersion = command.tosVersion,
             privacyAcceptedAt = command.privacyAcceptedAt,
@@ -81,8 +81,8 @@ class RegisterUserService(
             ResultState.INVALID,
             DomainError(ResultState.INVALID.code, "domain.user.register.invalid", "Une erreur est survenue")
         )
-        notificationPort.sendWelcomeEmail(userResult.username, command.email, userResult.subscriptionPlan)
-        emailVerificationIssuer.issue(userResult.id, command.email)
+        val verificationToken = emailVerificationIssuer.issue(userResult.id)
+        notificationPort.sendWelcomeWithVerificationEmail(userResult.username, command.email, userResult.subscriptionPlan, verificationToken.token)
         log.info("User registered successfully: plan={}", userResult.subscriptionPlan)
         return success(userResult)
     }

--- a/domain/src/main/kotlin/fr/sacane/jmanager/domain/port/input/user/RegisterUserUseCase.kt
+++ b/domain/src/main/kotlin/fr/sacane/jmanager/domain/port/input/user/RegisterUserUseCase.kt
@@ -12,6 +12,7 @@ import fr.sacane.jmanager.domain.port.input.FeatureFlagged
 import fr.sacane.jmanager.domain.port.output.Hasher
 import fr.sacane.jmanager.domain.port.output.NotificationPort
 import fr.sacane.jmanager.domain.port.output.UserRepository
+import fr.sacane.jmanager.domain.usecase.EmailVerificationIssuer
 import fr.sacane.jmanager.domain.utils.Result
 import fr.sacane.jmanager.domain.utils.DomainError
 import fr.sacane.jmanager.domain.utils.ResultState
@@ -42,6 +43,7 @@ class RegisterUserService(
     private val userRepository: UserRepository,
     private val hasher: Hasher,
     private val notificationPort: NotificationPort,
+    private val emailVerificationIssuer: EmailVerificationIssuer,
 ) : RegisterUserUseCase {
 
     companion object {
@@ -80,6 +82,7 @@ class RegisterUserService(
             DomainError(ResultState.INVALID.code, "domain.user.register.invalid", "Une erreur est survenue")
         )
         notificationPort.sendWelcomeEmail(userResult.username, command.email, userResult.subscriptionPlan)
+        emailVerificationIssuer.issue(userResult.id, command.email)
         log.info("User registered successfully: plan={}", userResult.subscriptionPlan)
         return success(userResult)
     }

--- a/domain/src/main/kotlin/fr/sacane/jmanager/domain/port/input/user/ResendVerificationEmailUseCase.kt
+++ b/domain/src/main/kotlin/fr/sacane/jmanager/domain/port/input/user/ResendVerificationEmailUseCase.kt
@@ -6,6 +6,7 @@ import fr.sacane.jmanager.domain.hexadoc.Side
 import fr.sacane.jmanager.domain.models.UserId
 import fr.sacane.jmanager.domain.port.input.Command
 import fr.sacane.jmanager.domain.port.input.CommandHandler
+import fr.sacane.jmanager.domain.port.output.NotificationPort
 import fr.sacane.jmanager.domain.port.output.UserRepository
 import fr.sacane.jmanager.domain.usecase.EmailVerificationIssuer
 import fr.sacane.jmanager.domain.utils.DomainError
@@ -24,6 +25,7 @@ interface ResendVerificationEmailUseCase : CommandHandler<ResendVerificationEmai
 @DomainService
 class ResendVerificationEmailService(
     private val userRepository: UserRepository,
+    private val notificationPort: NotificationPort,
     private val emailVerificationIssuer: EmailVerificationIssuer,
 ) : ResendVerificationEmailUseCase {
 
@@ -48,7 +50,8 @@ class ResendVerificationEmailService(
                 ResultState.INVALID,
                 DomainError(ResultState.INVALID.code, "domain.user.email_verification.no_email", "Aucune adresse e-mail associée à ce compte")
             )
-        emailVerificationIssuer.issue(user.id, email)
+        val token = emailVerificationIssuer.issue(user.id)
+        notificationPort.sendVerificationEmail(email, token.token)
         return success(Unit)
     }
 }

--- a/domain/src/main/kotlin/fr/sacane/jmanager/domain/port/input/user/ResendVerificationEmailUseCase.kt
+++ b/domain/src/main/kotlin/fr/sacane/jmanager/domain/port/input/user/ResendVerificationEmailUseCase.kt
@@ -1,0 +1,54 @@
+package fr.sacane.jmanager.domain.port.input.user
+
+import fr.sacane.jmanager.domain.hexadoc.DomainService
+import fr.sacane.jmanager.domain.hexadoc.Port
+import fr.sacane.jmanager.domain.hexadoc.Side
+import fr.sacane.jmanager.domain.models.UserId
+import fr.sacane.jmanager.domain.port.input.Command
+import fr.sacane.jmanager.domain.port.input.CommandHandler
+import fr.sacane.jmanager.domain.port.output.UserRepository
+import fr.sacane.jmanager.domain.usecase.EmailVerificationIssuer
+import fr.sacane.jmanager.domain.utils.DomainError
+import fr.sacane.jmanager.domain.utils.Result
+import fr.sacane.jmanager.domain.utils.ResultState
+import fr.sacane.jmanager.domain.utils.failure
+import fr.sacane.jmanager.domain.utils.success
+
+data class ResendVerificationEmailCommand(val userId: UserId) : Command<Unit>
+
+@Port(Side.APPLICATION)
+interface ResendVerificationEmailUseCase : CommandHandler<ResendVerificationEmailCommand, Unit> {
+    override val commandClass get() = ResendVerificationEmailCommand::class
+}
+
+@DomainService
+class ResendVerificationEmailService(
+    private val userRepository: UserRepository,
+    private val emailVerificationIssuer: EmailVerificationIssuer,
+) : ResendVerificationEmailUseCase {
+
+    override fun handle(command: ResendVerificationEmailCommand): Result<Unit> {
+        val user = userRepository.findUserById(command.userId)
+            ?: return failure(
+                ResultState.USER_NOT_FOUND,
+                DomainError(ResultState.USER_NOT_FOUND.code, "domain.user.email_verification.user_not_found", "Utilisateur introuvable")
+            )
+        if (user.emailVerified) {
+            return failure(
+                ResultState.EMAIL_ALREADY_VERIFIED,
+                DomainError(
+                    ResultState.EMAIL_ALREADY_VERIFIED.code,
+                    "domain.user.email_verification.already_verified",
+                    "L'adresse e-mail est déjà vérifiée"
+                )
+            )
+        }
+        val email = user.email
+            ?: return failure(
+                ResultState.INVALID,
+                DomainError(ResultState.INVALID.code, "domain.user.email_verification.no_email", "Aucune adresse e-mail associée à ce compte")
+            )
+        emailVerificationIssuer.issue(user.id, email)
+        return success(Unit)
+    }
+}

--- a/domain/src/main/kotlin/fr/sacane/jmanager/domain/port/input/user/VerifyEmailUseCase.kt
+++ b/domain/src/main/kotlin/fr/sacane/jmanager/domain/port/input/user/VerifyEmailUseCase.kt
@@ -1,0 +1,52 @@
+package fr.sacane.jmanager.domain.port.input.user
+
+import fr.sacane.jmanager.domain.hexadoc.DomainService
+import fr.sacane.jmanager.domain.hexadoc.Port
+import fr.sacane.jmanager.domain.hexadoc.Side
+import fr.sacane.jmanager.domain.port.input.Command
+import fr.sacane.jmanager.domain.port.input.CommandHandler
+import fr.sacane.jmanager.domain.port.output.UserRepository
+import fr.sacane.jmanager.domain.port.output.repository.EmailVerificationTokenRepository
+import fr.sacane.jmanager.domain.utils.DomainError
+import fr.sacane.jmanager.domain.utils.Result
+import fr.sacane.jmanager.domain.utils.ResultState
+import fr.sacane.jmanager.domain.utils.failure
+import fr.sacane.jmanager.domain.utils.success
+import java.time.Clock
+import java.time.LocalDateTime
+
+data class VerifyEmailCommand(val token: String) : Command<Unit>
+
+@Port(Side.APPLICATION)
+interface VerifyEmailUseCase : CommandHandler<VerifyEmailCommand, Unit> {
+    override val commandClass get() = VerifyEmailCommand::class
+}
+
+@DomainService
+class VerifyEmailService(
+    private val tokenRepository: EmailVerificationTokenRepository,
+    private val userRepository: UserRepository,
+    private val clock: Clock,
+) : VerifyEmailUseCase {
+
+    override fun handle(command: VerifyEmailCommand): Result<Unit> {
+        val token = tokenRepository.findByToken(command.token)
+            ?: return failure(
+                ResultState.NOT_FOUND,
+                DomainError(ResultState.NOT_FOUND.code, "domain.user.email_verification.token_not_found", "Token de vérification inconnu")
+            )
+        if (token.isExpired(LocalDateTime.now(clock))) {
+            return failure(
+                ResultState.EMAIL_VERIFICATION_TOKEN_EXPIRED,
+                DomainError(
+                    ResultState.EMAIL_VERIFICATION_TOKEN_EXPIRED.code,
+                    "domain.user.email_verification.token_expired",
+                    "Le lien de vérification a expiré"
+                )
+            )
+        }
+        userRepository.markEmailVerified(token.userId)
+        tokenRepository.deleteByUserId(token.userId)
+        return success(Unit)
+    }
+}

--- a/domain/src/main/kotlin/fr/sacane/jmanager/domain/port/output/NotificationPort.kt
+++ b/domain/src/main/kotlin/fr/sacane/jmanager/domain/port/output/NotificationPort.kt
@@ -6,19 +6,27 @@ import fr.sacane.jmanager.domain.models.SubscriptionPlan
 
 @Port(Side.INFRASTRUCTURE)
 interface NotificationPort {
-    /**
-     * Sends a welcome email to a newly registered user.
-     * The content adapts to the user's subscription plan.
-     *
-     * @param username the registered username
-     * @param email the destination email address
-     * @param subscriptionPlan the plan the user was registered under
-     */
-    fun sendWelcomeEmail(username: String, email: String, subscriptionPlan: SubscriptionPlan)
 
     /**
-     * Sends a verification email carrying a raw token.
-     * The infrastructure adapter is responsible for constructing the full verification link.
+     * Sends a single welcome email that also contains the email-verification link.
+     * Used by registration flows (self-registration and admin creation) so the user
+     * receives exactly one email per sign-up.
+     *
+     * @param username the registered username
+     * @param email the destination address
+     * @param subscriptionPlan drives the welcome message variant (FREE, BETA_TESTER, PREMIUM)
+     * @param verificationToken the raw token; the adapter builds the full verification URL
+     */
+    fun sendWelcomeWithVerificationEmail(
+        username: String,
+        email: String,
+        subscriptionPlan: SubscriptionPlan,
+        verificationToken: String,
+    )
+
+    /**
+     * Sends a standalone verification email.
+     * Used exclusively by the resend-verification flow when the user already exists.
      *
      * @param email the destination address
      * @param token the raw verification token to embed in the link

--- a/domain/src/main/kotlin/fr/sacane/jmanager/domain/port/output/NotificationPort.kt
+++ b/domain/src/main/kotlin/fr/sacane/jmanager/domain/port/output/NotificationPort.kt
@@ -15,4 +15,13 @@ interface NotificationPort {
      * @param subscriptionPlan the plan the user was registered under
      */
     fun sendWelcomeEmail(username: String, email: String, subscriptionPlan: SubscriptionPlan)
+
+    /**
+     * Sends a verification email carrying a raw token.
+     * The infrastructure adapter is responsible for constructing the full verification link.
+     *
+     * @param email the destination address
+     * @param token the raw verification token to embed in the link
+     */
+    fun sendVerificationEmail(email: String, token: String)
 }

--- a/domain/src/main/kotlin/fr/sacane/jmanager/domain/port/output/SecureTokenGenerator.kt
+++ b/domain/src/main/kotlin/fr/sacane/jmanager/domain/port/output/SecureTokenGenerator.kt
@@ -1,0 +1,10 @@
+package fr.sacane.jmanager.domain.port.output
+
+import fr.sacane.jmanager.domain.hexadoc.Port
+import fr.sacane.jmanager.domain.hexadoc.Side
+
+/** SPI contract for generating cryptographically secure, URL-safe random tokens. */
+@Port(Side.INFRASTRUCTURE)
+interface SecureTokenGenerator {
+    fun generate(): String
+}

--- a/domain/src/main/kotlin/fr/sacane/jmanager/domain/port/output/UserRepository.kt
+++ b/domain/src/main/kotlin/fr/sacane/jmanager/domain/port/output/UserRepository.kt
@@ -77,7 +77,16 @@ interface UserRepository {
         tosAcceptedAt: LocalDateTime? = null,
         tosVersion: String? = null,
         privacyAcceptedAt: LocalDateTime? = null,
+        emailVerified: Boolean = false,
     ): User?
+
+    /**
+     * Mark a user's email address as verified.
+     *
+     * @param userId domain UserId of the user to update
+     * @return success or USER_NOT_FOUND if the user does not exist
+     */
+    fun markEmailVerified(userId: UserId): Result<Unit>
 
     /**
      * Upsert (insert or update) a user aggregate.

--- a/domain/src/main/kotlin/fr/sacane/jmanager/domain/port/output/repository/EmailVerificationTokenRepository.kt
+++ b/domain/src/main/kotlin/fr/sacane/jmanager/domain/port/output/repository/EmailVerificationTokenRepository.kt
@@ -1,0 +1,13 @@
+package fr.sacane.jmanager.domain.port.output.repository
+
+import fr.sacane.jmanager.domain.hexadoc.Port
+import fr.sacane.jmanager.domain.hexadoc.Side
+import fr.sacane.jmanager.domain.models.EmailVerificationToken
+import fr.sacane.jmanager.domain.models.UserId
+
+@Port(Side.INFRASTRUCTURE)
+interface EmailVerificationTokenRepository {
+    fun save(token: EmailVerificationToken): EmailVerificationToken
+    fun findByToken(token: String): EmailVerificationToken?
+    fun deleteByUserId(userId: UserId)
+}

--- a/domain/src/main/kotlin/fr/sacane/jmanager/domain/usecase/EmailVerificationIssuer.kt
+++ b/domain/src/main/kotlin/fr/sacane/jmanager/domain/usecase/EmailVerificationIssuer.kt
@@ -1,0 +1,37 @@
+package fr.sacane.jmanager.domain.usecase
+
+import fr.sacane.jmanager.domain.models.EmailVerificationToken
+import fr.sacane.jmanager.domain.models.UserId
+import fr.sacane.jmanager.domain.port.output.NotificationPort
+import fr.sacane.jmanager.domain.port.output.SecureTokenGenerator
+import fr.sacane.jmanager.domain.port.output.repository.EmailVerificationTokenRepository
+import java.time.Clock
+import java.time.Duration
+import java.time.LocalDateTime
+
+/**
+ * Domain service that encapsulates the "issue a verification token and notify the user" operation.
+ * Used by both registration and resend flows to avoid duplicating token-lifecycle logic.
+ * Instantiated explicitly by EmailVerificationConfiguration (not via component scan) because it
+ * requires Clock and Duration which are not default Spring beans.
+ */
+class EmailVerificationIssuer(
+    private val tokenRepository: EmailVerificationTokenRepository,
+    private val secureTokenGenerator: SecureTokenGenerator,
+    private val notificationPort: NotificationPort,
+    private val clock: Clock,
+    private val tokenTtl: Duration = Duration.ofHours(24),
+) {
+    fun issue(userId: UserId, email: String): EmailVerificationToken {
+        tokenRepository.deleteByUserId(userId)
+        val rawToken = secureTokenGenerator.generate()
+        val token = EmailVerificationToken(
+            token = rawToken,
+            userId = userId,
+            expiresAt = LocalDateTime.now(clock).plus(tokenTtl),
+        )
+        tokenRepository.save(token)
+        notificationPort.sendVerificationEmail(email, rawToken)
+        return token
+    }
+}

--- a/domain/src/main/kotlin/fr/sacane/jmanager/domain/usecase/EmailVerificationIssuer.kt
+++ b/domain/src/main/kotlin/fr/sacane/jmanager/domain/usecase/EmailVerificationIssuer.kt
@@ -10,19 +10,22 @@ import java.time.Duration
 import java.time.LocalDateTime
 
 /**
- * Domain service that encapsulates the "issue a verification token and notify the user" operation.
- * Used by both registration and resend flows to avoid duplicating token-lifecycle logic.
+ * Domain service responsible solely for the verification-token lifecycle:
+ * invalidate any existing token for the user, generate a fresh one, persist it, and return it.
+ *
+ * Notification is intentionally excluded — callers decide which email variant to send
+ * (combined welcome+verification for new registrations, standalone for resend).
+ *
  * Instantiated explicitly by EmailVerificationConfiguration (not via component scan) because it
  * requires Clock and Duration which are not default Spring beans.
  */
 class EmailVerificationIssuer(
     private val tokenRepository: EmailVerificationTokenRepository,
     private val secureTokenGenerator: SecureTokenGenerator,
-    private val notificationPort: NotificationPort,
     private val clock: Clock,
     private val tokenTtl: Duration = Duration.ofHours(24),
 ) {
-    fun issue(userId: UserId, email: String): EmailVerificationToken {
+    fun issue(userId: UserId): EmailVerificationToken {
         tokenRepository.deleteByUserId(userId)
         val rawToken = secureTokenGenerator.generate()
         val token = EmailVerificationToken(
@@ -31,7 +34,6 @@ class EmailVerificationIssuer(
             expiresAt = LocalDateTime.now(clock).plus(tokenTtl),
         )
         tokenRepository.save(token)
-        notificationPort.sendVerificationEmail(email, rawToken)
         return token
     }
 }

--- a/domain/src/main/kotlin/fr/sacane/jmanager/domain/utils/Result.kt
+++ b/domain/src/main/kotlin/fr/sacane/jmanager/domain/utils/Result.kt
@@ -27,7 +27,10 @@ enum class ResultState (val code: Int){
     TRANSACTION_ENTRY_ERROR(5000),
     REGISTRATION_ERROR(5001),
 
-    BOOKLET_MAXIMUM_SIZE_REACHED(2004);
+    BOOKLET_MAXIMUM_SIZE_REACHED(2004),
+
+    EMAIL_VERIFICATION_TOKEN_EXPIRED(6001),
+    EMAIL_ALREADY_VERIFIED(6002);
 
     fun isSuccess(): Boolean = this == OK
     fun isFailure(): Boolean = !isSuccess()

--- a/domain/src/test/kotlin/fr/sacane/jmanager/domain/fake/FakeFactory.kt
+++ b/domain/src/test/kotlin/fr/sacane/jmanager/domain/fake/FakeFactory.kt
@@ -22,6 +22,11 @@ import fr.sacane.jmanager.domain.port.input.user.*
 import fr.sacane.jmanager.domain.port.input.user.DeleteAccountService
 import fr.sacane.jmanager.domain.port.input.user.HasUserConsentedService
 import fr.sacane.jmanager.domain.port.input.user.RecordConsentService
+import fr.sacane.jmanager.domain.port.output.SecureTokenGenerator
+import fr.sacane.jmanager.domain.usecase.EmailVerificationIssuer
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
 import fr.sacane.jmanager.domain.port.input.retention.PurgeExpiredDataService
 import fr.sacane.jmanager.domain.port.output.*
 import fr.sacane.jmanager.domain.port.output.repository.BookletBalanceQueryRepository
@@ -38,6 +43,8 @@ import fr.sacane.jmanager.domain.usecase.TrendCalculatorImpl
 import java.util.*
 
 class FakeFactory {
+    val fixedClock: Clock = Clock.fixed(Instant.parse("2026-05-31T10:00:00Z"), ZoneOffset.UTC)
+
     private val inMemoryDatabase = InMemoryDatabase()
     private val  inMemoryTrackerRepository: RegularTransactionTrackerRepository = InMemoryRegularTrackerRepository(inMemoryDatabase)
     private val  bookletRepository: InMemoryBookletRepository = InMemoryBookletRepository(inMemoryDatabase)
@@ -118,13 +125,23 @@ class FakeFactory {
     val logoutService = LogoutService(sessionManager)
     val refreshSessionService = RefreshSessionService(sessionManager, userRepository, tokenGenerator)
     val fakeNotificationPort = FakeNotificationPort()
-    val registerUserService = RegisterUserService(userRepository, DefaultHasher, fakeNotificationPort)
+    private val fakeSecureTokenGenerator = object : SecureTokenGenerator {
+        override fun generate(): String = java.util.UUID.randomUUID().toString()
+    }
+    private val inMemoryEmailVerificationTokenRepository = InMemoryEmailVerificationTokenRepository()
+    val emailVerificationIssuer = EmailVerificationIssuer(
+        inMemoryEmailVerificationTokenRepository, fakeSecureTokenGenerator, fakeNotificationPort, fixedClock
+    )
+    val verifyEmailService = VerifyEmailService(inMemoryEmailVerificationTokenRepository, userRepository, fixedClock)
+    val resendVerificationEmailService = ResendVerificationEmailService(userRepository, emailVerificationIssuer)
+    val registerUserService = RegisterUserService(userRepository, DefaultHasher, fakeNotificationPort, emailVerificationIssuer)
     val createAdminIfNotExistsService = CreateAdminIfNotExistsService(userRepository, DefaultHasher)
     val getUserSettingsService = GetUserSettingsService(userRepository)
     val updateUserSettingsService = UpdateUserSettingsService(userRepository, bookletRepository)
     val deleteAccountService = DeleteAccountService(userRepository)
     val recordConsentService = RecordConsentService(userRepository)
     val hasUserConsentedService = HasUserConsentedService(userRepository)
+    val getUserEmailVerifiedService = GetUserEmailVerifiedService(userRepository)
     private val inMemoryFeatureFlagRepository = InMemoryFeatureFlagRepository()
     val isFeatureEnabledService = IsFeatureEnabledService(inMemoryFeatureFlagRepository)
     val getAllFeatureFlagsService = GetAllFeatureFlagsService(inMemoryFeatureFlagRepository)
@@ -170,11 +187,13 @@ class FakeFactory {
         inMemoryTagRepository.clear()
         fakeNotificationPort.clear()
         inMemoryFeatureFlagRepository.clear()
+        inMemoryEmailVerificationTokenRepository.clear()
     }
 
-    fun fakeUserRepository(): InMemoryUserRepository {
-        return userRepository
-    }
+    fun fakeUserRepository(): InMemoryUserRepository = userRepository
+
+    fun fakeEmailVerificationTokenRepository(): InMemoryEmailVerificationTokenRepository =
+        inMemoryEmailVerificationTokenRepository
 
     fun fakeTransactionRepository(): State<IdBookletByTransaction> {
         return transactionRepository

--- a/domain/src/test/kotlin/fr/sacane/jmanager/domain/fake/FakeFactory.kt
+++ b/domain/src/test/kotlin/fr/sacane/jmanager/domain/fake/FakeFactory.kt
@@ -19,6 +19,8 @@ import fr.sacane.jmanager.domain.port.input.stats.*
 import fr.sacane.jmanager.domain.port.input.tag.*
 import fr.sacane.jmanager.domain.port.input.transaction.*
 import fr.sacane.jmanager.domain.port.input.user.*
+import fr.sacane.jmanager.domain.port.input.admin.AdminCreateUserService
+import fr.sacane.jmanager.domain.port.input.admin.AdminCreateUserUseCase
 import fr.sacane.jmanager.domain.port.input.user.DeleteAccountService
 import fr.sacane.jmanager.domain.port.input.user.HasUserConsentedService
 import fr.sacane.jmanager.domain.port.input.user.RecordConsentService
@@ -130,11 +132,12 @@ class FakeFactory {
     }
     private val inMemoryEmailVerificationTokenRepository = InMemoryEmailVerificationTokenRepository()
     val emailVerificationIssuer = EmailVerificationIssuer(
-        inMemoryEmailVerificationTokenRepository, fakeSecureTokenGenerator, fakeNotificationPort, fixedClock
+        inMemoryEmailVerificationTokenRepository, fakeSecureTokenGenerator, fixedClock
     )
     val verifyEmailService = VerifyEmailService(inMemoryEmailVerificationTokenRepository, userRepository, fixedClock)
-    val resendVerificationEmailService = ResendVerificationEmailService(userRepository, emailVerificationIssuer)
+    val resendVerificationEmailService = ResendVerificationEmailService(userRepository, fakeNotificationPort, emailVerificationIssuer)
     val registerUserService = RegisterUserService(userRepository, DefaultHasher, fakeNotificationPort, emailVerificationIssuer)
+    val adminCreateUserUseCase: AdminCreateUserUseCase = AdminCreateUserService(userRepository, DefaultHasher, fakeNotificationPort, emailVerificationIssuer)
     val createAdminIfNotExistsService = CreateAdminIfNotExistsService(userRepository, DefaultHasher)
     val getUserSettingsService = GetUserSettingsService(userRepository)
     val updateUserSettingsService = UpdateUserSettingsService(userRepository, bookletRepository)

--- a/domain/src/test/kotlin/fr/sacane/jmanager/domain/fake/FakeNotificationPort.kt
+++ b/domain/src/test/kotlin/fr/sacane/jmanager/domain/fake/FakeNotificationPort.kt
@@ -5,19 +5,30 @@ import fr.sacane.jmanager.domain.port.output.NotificationPort
 
 class FakeNotificationPort : NotificationPort {
 
-    data class SentEmail(
+    data class SentWelcomeEmail(
         val username: String,
         val email: String,
         val subscriptionPlan: SubscriptionPlan,
     )
 
-    val sentEmails: MutableList<SentEmail> = mutableListOf()
+    data class SentVerificationEmail(
+        val email: String,
+        val token: String,
+    )
+
+    val sentEmails: MutableList<SentWelcomeEmail> = mutableListOf()
+    val sentVerificationEmails: MutableList<SentVerificationEmail> = mutableListOf()
 
     override fun sendWelcomeEmail(username: String, email: String, subscriptionPlan: SubscriptionPlan) {
-        sentEmails.add(SentEmail(username, email, subscriptionPlan))
+        sentEmails.add(SentWelcomeEmail(username, email, subscriptionPlan))
+    }
+
+    override fun sendVerificationEmail(email: String, token: String) {
+        sentVerificationEmails.add(SentVerificationEmail(email, token))
     }
 
     fun clear() {
         sentEmails.clear()
+        sentVerificationEmails.clear()
     }
 }

--- a/domain/src/test/kotlin/fr/sacane/jmanager/domain/fake/FakeNotificationPort.kt
+++ b/domain/src/test/kotlin/fr/sacane/jmanager/domain/fake/FakeNotificationPort.kt
@@ -5,10 +5,11 @@ import fr.sacane.jmanager.domain.port.output.NotificationPort
 
 class FakeNotificationPort : NotificationPort {
 
-    data class SentWelcomeEmail(
+    data class SentCombinedEmail(
         val username: String,
         val email: String,
         val subscriptionPlan: SubscriptionPlan,
+        val verificationToken: String,
     )
 
     data class SentVerificationEmail(
@@ -16,11 +17,16 @@ class FakeNotificationPort : NotificationPort {
         val token: String,
     )
 
-    val sentEmails: MutableList<SentWelcomeEmail> = mutableListOf()
+    val sentCombinedEmails: MutableList<SentCombinedEmail> = mutableListOf()
     val sentVerificationEmails: MutableList<SentVerificationEmail> = mutableListOf()
 
-    override fun sendWelcomeEmail(username: String, email: String, subscriptionPlan: SubscriptionPlan) {
-        sentEmails.add(SentWelcomeEmail(username, email, subscriptionPlan))
+    override fun sendWelcomeWithVerificationEmail(
+        username: String,
+        email: String,
+        subscriptionPlan: SubscriptionPlan,
+        verificationToken: String,
+    ) {
+        sentCombinedEmails.add(SentCombinedEmail(username, email, subscriptionPlan, verificationToken))
     }
 
     override fun sendVerificationEmail(email: String, token: String) {
@@ -28,7 +34,7 @@ class FakeNotificationPort : NotificationPort {
     }
 
     fun clear() {
-        sentEmails.clear()
+        sentCombinedEmails.clear()
         sentVerificationEmails.clear()
     }
 }

--- a/domain/src/test/kotlin/fr/sacane/jmanager/domain/fake/InMemoryEmailVerificationTokenRepository.kt
+++ b/domain/src/test/kotlin/fr/sacane/jmanager/domain/fake/InMemoryEmailVerificationTokenRepository.kt
@@ -1,0 +1,50 @@
+package fr.sacane.jmanager.domain.fake
+
+import fr.sacane.jmanager.domain.models.EmailVerificationToken
+import fr.sacane.jmanager.domain.models.UserId
+import fr.sacane.jmanager.domain.port.output.repository.EmailVerificationTokenRepository
+import java.time.Clock
+import java.time.Duration
+import java.time.LocalDateTime
+
+class InMemoryEmailVerificationTokenRepository : EmailVerificationTokenRepository {
+
+    private val store: MutableMap<String, EmailVerificationToken> = mutableMapOf()
+
+    override fun save(token: EmailVerificationToken): EmailVerificationToken {
+        store[token.token] = token
+        return token
+    }
+
+    override fun findByToken(token: String): EmailVerificationToken? = store[token]
+
+    override fun deleteByUserId(userId: UserId) {
+        store.entries.removeIf { it.value.userId == userId }
+    }
+
+    // --- Test helpers ---
+
+    /** Saves a fresh (non-expired) token and returns the raw token string. */
+    fun issueFreshToken(userId: UserId, clock: Clock, ttl: Duration = Duration.ofHours(24)): String {
+        val raw = "fresh-token-${userId.value}"
+        val token = EmailVerificationToken(raw, userId, LocalDateTime.now(clock).plus(ttl))
+        save(token)
+        return raw
+    }
+
+    /** Saves an already-expired token and returns the raw token string. */
+    fun issueExpiredToken(userId: UserId): String {
+        val raw = "expired-token-${userId.value}"
+        val token = EmailVerificationToken(raw, userId, LocalDateTime.of(2000, 1, 1, 0, 0))
+        save(token)
+        return raw
+    }
+
+    fun hasTokenForUser(userId: UserId): Boolean = store.values.any { it.userId == userId }
+
+    fun countForUser(userId: UserId): Int = store.values.count { it.userId == userId }
+
+    fun existsByToken(token: String): Boolean = store.containsKey(token)
+
+    fun clear() = store.clear()
+}

--- a/domain/src/test/kotlin/fr/sacane/jmanager/domain/fake/InMemoryRepository.kt
+++ b/domain/src/test/kotlin/fr/sacane/jmanager/domain/fake/InMemoryRepository.kt
@@ -137,13 +137,19 @@ class InMemoryUserRepository (
         return user.user
     }
 
-    override fun register(username: String, password: String, roles: Set<Role>, subscriptionPlan: SubscriptionPlan, email: String?, tosAcceptedAt: LocalDateTime?, tosVersion: String?, privacyAcceptedAt: LocalDateTime?): User {
+    override fun register(username: String, password: String, roles: Set<Role>, subscriptionPlan: SubscriptionPlan, email: String?, tosAcceptedAt: LocalDateTime?, tosVersion: String?, privacyAcceptedAt: LocalDateTime?, emailVerified: Boolean): User {
         val consent = if (tosAcceptedAt != null && privacyAcceptedAt != null) {
             ConsentRecord(tosAcceptedAt, tosVersion, privacyAcceptedAt)
         } else null
-        val element = User(id = UserId(UUID.randomUUID()), username = username, email = email, roles = roles, subscriptionPlan = subscriptionPlan, consent = consent)
+        val element = User(id = UserId(UUID.randomUUID()), username = username, email = email, roles = roles, subscriptionPlan = subscriptionPlan, consent = consent, emailVerified = emailVerified)
         inMemoryDatabase.users[element.id] = UserWithPassword(element, password, roles)
         return element
+    }
+
+    override fun markEmailVerified(userId: UserId): Result<Unit> {
+        val userWithPassword = inMemoryDatabase.users[userId] ?: return Result(ResultState.USER_NOT_FOUND)
+        userWithPassword.user.emailVerified = true
+        return success(Unit)
     }
 
     override fun upsert(user: User): User? {

--- a/domain/src/test/kotlin/fr/sacane/jmanager/domain/fixture/UserFixture.kt
+++ b/domain/src/test/kotlin/fr/sacane/jmanager/domain/fixture/UserFixture.kt
@@ -13,8 +13,9 @@ object UserFixture {
     fun aUser(
         id: UserId = UserId(UUID.randomUUID()),
         username: String = "john",
-        email: String? = ""
-    ) = User(id, username, email)
+        email: String? = "",
+        emailVerified: Boolean = false,
+    ) = User(id = id, username = username, email = email, emailVerified = emailVerified)
 
     fun aUserWithPassword(
         user: User = aUser(),

--- a/domain/src/test/kotlin/fr/sacane/jmanager/domain/port/EmailVerificationFeatureTest.kt
+++ b/domain/src/test/kotlin/fr/sacane/jmanager/domain/port/EmailVerificationFeatureTest.kt
@@ -41,6 +41,7 @@ class EmailVerificationFeatureTest {
     private val resendVerificationEmailUseCase = factory.resendVerificationEmailService
     private val registerUserUseCase = factory.registerUserService
     private val sentVerificationEmails get() = factory.fakeNotificationPort.sentVerificationEmails
+    private val sentCombinedEmails get() = factory.fakeNotificationPort.sentCombinedEmails
 
     @AfterEach
     fun tearDown() {
@@ -166,11 +167,12 @@ class EmailVerificationFeatureTest {
         }
 
         @Test
-        fun `self-registered user receives a verification email`() {
+        fun `self-registered user receives a single combined welcome and verification email`() {
             act { registerUserUseCase.handle(registerCommand(email = "dave@example.com")) }
 
-            assertEquals(1, sentVerificationEmails.size)
-            assertEquals("dave@example.com", sentVerificationEmails.first().email)
+            assertEquals(1, sentCombinedEmails.size)
+            assertEquals("dave@example.com", sentCombinedEmails.first().email)
+            assertEquals(0, sentVerificationEmails.size)
         }
 
         @Test

--- a/domain/src/test/kotlin/fr/sacane/jmanager/domain/port/EmailVerificationFeatureTest.kt
+++ b/domain/src/test/kotlin/fr/sacane/jmanager/domain/port/EmailVerificationFeatureTest.kt
@@ -1,0 +1,184 @@
+package fr.sacane.jmanager.domain.port
+
+import fr.sacane.jmanager.domain.act
+import fr.sacane.jmanager.domain.assertFailure
+import fr.sacane.jmanager.domain.assertSuccess
+import fr.sacane.jmanager.domain.fake.FakeFactory
+import fr.sacane.jmanager.domain.fixture.UserFixture
+import fr.sacane.jmanager.domain.initWith
+import fr.sacane.jmanager.domain.port.input.user.RegisterUserCommand
+import fr.sacane.jmanager.domain.port.input.user.ResendVerificationEmailCommand
+import fr.sacane.jmanager.domain.port.input.user.VerifyEmailCommand
+import fr.sacane.jmanager.domain.then
+import fr.sacane.jmanager.domain.utils.ResultState
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+
+private fun registerCommand(
+    username: String = "carol",
+    email: String = "carol@example.com",
+) = RegisterUserCommand(
+    username = username,
+    password = "pass",
+    confirmPassword = "pass",
+    email = email,
+    tosAcceptedAt = LocalDateTime.of(2026, 1, 1, 10, 0),
+    tosVersion = "1.0",
+    privacyAcceptedAt = LocalDateTime.of(2026, 1, 1, 10, 0),
+)
+
+class EmailVerificationFeatureTest {
+
+    private val factory = FakeFactory()
+    private val userState = factory.fakeUserRepository()
+    private val tokenState = factory.fakeEmailVerificationTokenRepository()
+    private val verifyEmailUseCase = factory.verifyEmailService
+    private val resendVerificationEmailUseCase = factory.resendVerificationEmailService
+    private val registerUserUseCase = factory.registerUserService
+    private val sentVerificationEmails get() = factory.fakeNotificationPort.sentVerificationEmails
+
+    @AfterEach
+    fun tearDown() {
+        factory.clearAll()
+    }
+
+    @Nested
+    inner class VerifyEmailTest {
+
+        @Test
+        fun `valid token marks user email as verified`() {
+            val user = UserFixture.aUser(email = "alice@example.com")
+            userState.initWith(UserFixture.aUserWithPassword(user = user))
+            val rawToken = tokenState.issueFreshToken(user.id, factory.fixedClock)
+
+            val result = act { verifyEmailUseCase.handle(VerifyEmailCommand(rawToken)) }
+
+            then(result) { assertSuccess() }
+            assertTrue(userState.findUserById(user.id)!!.emailVerified)
+        }
+
+        @Test
+        fun `verifying a valid token deletes all tokens for the user`() {
+            val user = UserFixture.aUser()
+            userState.initWith(UserFixture.aUserWithPassword(user = user))
+            val rawToken = tokenState.issueFreshToken(user.id, factory.fixedClock)
+
+            act { verifyEmailUseCase.handle(VerifyEmailCommand(rawToken)) }
+
+            assertFalse(tokenState.hasTokenForUser(user.id))
+        }
+
+        @Test
+        fun `expired token is rejected and email remains unverified`() {
+            val user = UserFixture.aUser()
+            userState.initWith(UserFixture.aUserWithPassword(user = user))
+            val rawToken = tokenState.issueExpiredToken(user.id)
+
+            val result = act { verifyEmailUseCase.handle(VerifyEmailCommand(rawToken)) }
+
+            then(result) {
+                assertFailure(ResultState.EMAIL_VERIFICATION_TOKEN_EXPIRED)
+                assertEquals("domain.user.email_verification.token_expired", errorInfo?.key)
+            }
+            assertFalse(userState.findUserById(user.id)!!.emailVerified)
+        }
+
+        @Test
+        fun `unknown token is rejected`() {
+            val result = act { verifyEmailUseCase.handle(VerifyEmailCommand("does-not-exist")) }
+
+            then(result) {
+                assertFailure(ResultState.NOT_FOUND)
+                assertEquals("domain.user.email_verification.token_not_found", errorInfo?.key)
+            }
+        }
+    }
+
+    @Nested
+    inner class ResendVerificationEmailTest {
+
+        @Test
+        fun `resend issues a fresh token and sends a new verification email`() {
+            val user = UserFixture.aUser(email = "bob@example.com")
+            userState.initWith(UserFixture.aUserWithPassword(user = user))
+
+            val result = act { resendVerificationEmailUseCase.handle(ResendVerificationEmailCommand(user.id)) }
+
+            then(result) { assertSuccess() }
+            assertEquals(1, sentVerificationEmails.size)
+            assertEquals("bob@example.com", sentVerificationEmails.first().email)
+        }
+
+        @Test
+        fun `resend deletes the previous token before issuing a new one`() {
+            val user = UserFixture.aUser(email = "bob@example.com")
+            userState.initWith(UserFixture.aUserWithPassword(user = user))
+            val oldRawToken = tokenState.issueFreshToken(user.id, factory.fixedClock)
+
+            act { resendVerificationEmailUseCase.handle(ResendVerificationEmailCommand(user.id)) }
+
+            assertEquals(1, tokenState.countForUser(user.id))
+            assertFalse(tokenState.existsByToken(oldRawToken))
+            val newToken = sentVerificationEmails.last().token
+            assertTrue(tokenState.existsByToken(newToken))
+        }
+
+        @Test
+        fun `resend is rejected for an already-verified user`() {
+            val user = UserFixture.aUser(email = "verified@example.com", emailVerified = true)
+            userState.initWith(UserFixture.aUserWithPassword(user = user))
+
+            val result = act { resendVerificationEmailUseCase.handle(ResendVerificationEmailCommand(user.id)) }
+
+            then(result) {
+                assertFailure(ResultState.EMAIL_ALREADY_VERIFIED)
+                assertEquals("domain.user.email_verification.already_verified", errorInfo?.key)
+            }
+            assertEquals(0, sentVerificationEmails.size)
+        }
+
+        @Test
+        fun `resend for an unknown user returns USER_NOT_FOUND`() {
+            val result = act {
+                resendVerificationEmailUseCase.handle(ResendVerificationEmailCommand(UserFixture.aUser().id))
+            }
+
+            then(result) { assertFailure(ResultState.USER_NOT_FOUND) }
+        }
+    }
+
+    @Nested
+    inner class RegistrationWithVerificationTest {
+
+        @Test
+        fun `self-registered user is created with emailVerified false`() {
+            val result = act { registerUserUseCase.handle(registerCommand()) }
+
+            then(result) {
+                assertSuccess()
+                assertFalse(mapNotNullOrFailure()!!.emailVerified)
+            }
+        }
+
+        @Test
+        fun `self-registered user receives a verification email`() {
+            act { registerUserUseCase.handle(registerCommand(email = "dave@example.com")) }
+
+            assertEquals(1, sentVerificationEmails.size)
+            assertEquals("dave@example.com", sentVerificationEmails.first().email)
+        }
+
+        @Test
+        fun `self-registration saves a verification token`() {
+            val result = act { registerUserUseCase.handle(registerCommand()) }
+
+            val userId = result.mapNotNullOrFailure()!!.id
+            assertTrue(tokenState.hasTokenForUser(userId))
+        }
+    }
+}

--- a/domain/src/test/kotlin/fr/sacane/jmanager/domain/port/UserFeatureTest.kt
+++ b/domain/src/test/kotlin/fr/sacane/jmanager/domain/port/UserFeatureTest.kt
@@ -317,6 +317,13 @@ class UserFeatureTest {
         }
 
         @Test
+        fun `Admin-created user is automatically email-verified`() {
+            val result = act { createAdminIfNotExistsUseCase.handle(CreateAdminIfNotExistsCommand("admin", "test")) }
+
+            then(result) { assertTrue { emailVerified } }
+        }
+
+        @Test
         fun `Create admin with different password must return password not match`() {
             createAdminIfNotExistsUseCase.handle(CreateAdminIfNotExistsCommand("admin", "test"))
 

--- a/domain/src/test/kotlin/fr/sacane/jmanager/domain/port/UserFeatureTest.kt
+++ b/domain/src/test/kotlin/fr/sacane/jmanager/domain/port/UserFeatureTest.kt
@@ -21,6 +21,8 @@ import fr.sacane.jmanager.domain.port.input.user.LogoutUseCase
 import fr.sacane.jmanager.domain.port.input.user.RefreshSessionCommand
 import fr.sacane.jmanager.domain.port.input.user.RefreshSessionUseCase
 import fr.sacane.jmanager.domain.models.SubscriptionPlan
+import fr.sacane.jmanager.domain.port.input.admin.AdminCreateUserCommand
+import fr.sacane.jmanager.domain.port.input.admin.AdminCreateUserUseCase
 import fr.sacane.jmanager.domain.port.input.user.RegisterUserCommand
 import fr.sacane.jmanager.domain.port.input.user.RegisterUserUseCase
 import java.time.LocalDateTime
@@ -68,6 +70,7 @@ class UserFeatureTest {
     private val logoutUseCase: LogoutUseCase = factory.logoutService
     private val refreshSessionUseCase: RefreshSessionUseCase = factory.refreshSessionService
     private val registerUserUseCase: RegisterUserUseCase = factory.registerUserService
+    private val adminCreateUserUseCase: AdminCreateUserUseCase = factory.adminCreateUserUseCase
     private val createAdminIfNotExistsUseCase: CreateAdminIfNotExistsUseCase = factory.createAdminIfNotExistsService
     private val getUserSettingsUseCase: GetUserSettingsUseCase = factory.getUserSettingsService
     private val updateUserSettingsUseCase: UpdateUserSettingsUseCase = factory.updateUserSettingsService
@@ -77,7 +80,7 @@ class UserFeatureTest {
     private val sessionFakeState = factory.sessionState()
     private val userState = factory.fakeUserRepository()
     private val tokenGenerator = factory.tokenGenerator
-    private val sentEmails get() = factory.fakeNotificationPort.sentEmails
+    private val sentCombinedEmails get() = factory.fakeNotificationPort.sentCombinedEmails
 
     @AfterEach
     fun afterEach() {
@@ -218,38 +221,39 @@ class UserFeatureTest {
         }
 
         @Test
-        fun `Registered user defaults to BETA_TESTER subscription plan`() {
+        fun `Self-registered user gets FREE subscription plan`() {
             val result = act { registerUserUseCase.handle(registerCommand()) }
 
             then(result) {
                 assertSuccess()
-                assertEquals(SubscriptionPlan.BETA_TESTER, mapNotNullOrFailure()!!.subscriptionPlan)
+                assertEquals(SubscriptionPlan.FREE, mapNotNullOrFailure()!!.subscriptionPlan)
             }
         }
 
         @Test
-        fun `Welcome email is sent after successful registration`() {
+        fun `Welcome email with verification link is sent after successful registration`() {
             act { registerUserUseCase.handle(registerCommand()) }
 
-            assertEquals(1, sentEmails.size)
-            val sent = sentEmails.first()
+            assertEquals(1, sentCombinedEmails.size)
+            val sent = sentCombinedEmails.first()
             assertEquals("John", sent.username)
             assertEquals("john@example.com", sent.email)
-            assertEquals(SubscriptionPlan.BETA_TESTER, sent.subscriptionPlan)
+            assertEquals(SubscriptionPlan.FREE, sent.subscriptionPlan)
+            assertNotNull(sent.verificationToken)
         }
 
         @Test
         fun `Welcome email is not sent when passwords do not match`() {
             act { registerUserUseCase.handle(registerCommand(confirmPassword = "wrong")) }
 
-            assertEquals(0, sentEmails.size)
+            assertEquals(0, sentCombinedEmails.size)
         }
 
         @Test
         fun `Welcome email is not sent when email is blank`() {
             act { registerUserUseCase.handle(registerCommand(email = "")) }
 
-            assertEquals(0, sentEmails.size)
+            assertEquals(0, sentCombinedEmails.size)
         }
 
         @Test
@@ -295,6 +299,49 @@ class UserFeatureTest {
                 assertEquals("1.0", user.consent!!.tosVersion)
                 assertEquals(consentTime, user.consent!!.privacyAcceptedAt)
             }
+        }
+    }
+
+    @Nested
+    inner class AdminCreateUserFeatureTest {
+
+        @Test
+        fun `Admin-created user gets BETA_TESTER subscription plan`() {
+            val result = act { adminCreateUserUseCase.handle(AdminCreateUserCommand("beta", "pass", "beta@example.com")) }
+
+            then(result) {
+                assertSuccess()
+                assertEquals(SubscriptionPlan.BETA_TESTER, mapNotNullOrFailure()!!.subscriptionPlan)
+            }
+        }
+
+        @Test
+        fun `Admin-created user receives beta-tester welcome email with verification link`() {
+            act { adminCreateUserUseCase.handle(AdminCreateUserCommand("beta", "pass", "beta@example.com")) }
+
+            assertEquals(1, sentCombinedEmails.size)
+            val sent = sentCombinedEmails.first()
+            assertEquals("beta", sent.username)
+            assertEquals("beta@example.com", sent.email)
+            assertEquals(SubscriptionPlan.BETA_TESTER, sent.subscriptionPlan)
+            assertNotNull(sent.verificationToken)
+        }
+
+        @Test
+        fun `Admin creation fails when email is blank`() {
+            val result = act { adminCreateUserUseCase.handle(AdminCreateUserCommand("beta", "pass", "")) }
+
+            then(result) {
+                assertFailure(ResultState.INVALID)
+                assertEquals("domain.user.admin.create.email_required", errorInfo?.key)
+            }
+        }
+
+        @Test
+        fun `Admin creation welcome email is not sent when email is blank`() {
+            act { adminCreateUserUseCase.handle(AdminCreateUserCommand("beta", "pass", "")) }
+
+            assertEquals(0, sentCombinedEmails.size)
         }
     }
 

--- a/infrastructure/src/main/kotlin/fr/sacane/jmanager/infrastructure/spi/adapters/EmailVerificationTokenRepositoryJpaAdapter.kt
+++ b/infrastructure/src/main/kotlin/fr/sacane/jmanager/infrastructure/spi/adapters/EmailVerificationTokenRepositoryJpaAdapter.kt
@@ -1,0 +1,43 @@
+package fr.sacane.jmanager.infrastructure.spi.adapters
+
+import fr.sacane.jmanager.domain.hexadoc.Adapter
+import fr.sacane.jmanager.domain.hexadoc.Side
+import fr.sacane.jmanager.domain.models.EmailVerificationToken
+import fr.sacane.jmanager.domain.models.UserId
+import fr.sacane.jmanager.domain.port.output.repository.EmailVerificationTokenRepository
+import fr.sacane.jmanager.infrastructure.spi.entity.EmailVerificationTokenEntity
+import fr.sacane.jmanager.infrastructure.spi.repositories.EmailVerificationTokenJpaRepository
+import jakarta.transaction.Transactional
+import org.springframework.stereotype.Service
+
+@Service
+@Adapter(Side.INFRASTRUCTURE)
+class EmailVerificationTokenRepositoryJpaAdapter(
+    private val jpaRepository: EmailVerificationTokenJpaRepository,
+) : EmailVerificationTokenRepository {
+
+    override fun save(token: EmailVerificationToken): EmailVerificationToken {
+        jpaRepository.save(token.toEntity())
+        return token
+    }
+
+    override fun findByToken(token: String): EmailVerificationToken? =
+        jpaRepository.findById(token).orElse(null)?.toDomain()
+
+    @Transactional
+    override fun deleteByUserId(userId: UserId) {
+        userId.value?.let { jpaRepository.deleteByUserId(it) }
+    }
+
+    private fun EmailVerificationToken.toEntity() = EmailVerificationTokenEntity(
+        token = token,
+        userId = userId.value,
+        expiresAt = expiresAt,
+    )
+
+    private fun EmailVerificationTokenEntity.toDomain() = EmailVerificationToken(
+        token = token,
+        userId = UserId(userId),
+        expiresAt = expiresAt,
+    )
+}

--- a/infrastructure/src/main/kotlin/fr/sacane/jmanager/infrastructure/spi/adapters/SpringMailNotificationAdapter.kt
+++ b/infrastructure/src/main/kotlin/fr/sacane/jmanager/infrastructure/spi/adapters/SpringMailNotificationAdapter.kt
@@ -25,6 +25,24 @@ class SpringMailNotificationAdapter(
     }
 
     @Async
+    override fun sendVerificationEmail(email: String, token: String) {
+        val verificationLink = "$appUrl/verify-email?token=$token"
+        val content = EmailTemplates.verificationEmail(verificationLink)
+        try {
+            val mimeMessage = mailSender.createMimeMessage()
+            MimeMessageHelper(mimeMessage, false, "UTF-8").apply {
+                setTo(email)
+                setFrom(fromValue)
+                setSubject(content.subject)
+                setText(content.htmlBody, true)
+            }
+            mailSender.send(mimeMessage)
+        } catch (e: Exception) {
+            LOGGER.severe("Failed to send verification email: ${e.javaClass.simpleName}")
+        }
+    }
+
+    @Async
     override fun sendWelcomeEmail(username: String, email: String, subscriptionPlan: SubscriptionPlan) {
         val content = when (subscriptionPlan) {
             SubscriptionPlan.BETA_TESTER -> EmailTemplates.betaTester(username, appUrl)

--- a/infrastructure/src/main/kotlin/fr/sacane/jmanager/infrastructure/spi/adapters/SpringMailNotificationAdapter.kt
+++ b/infrastructure/src/main/kotlin/fr/sacane/jmanager/infrastructure/spi/adapters/SpringMailNotificationAdapter.kt
@@ -43,11 +43,17 @@ class SpringMailNotificationAdapter(
     }
 
     @Async
-    override fun sendWelcomeEmail(username: String, email: String, subscriptionPlan: SubscriptionPlan) {
+    override fun sendWelcomeWithVerificationEmail(
+        username: String,
+        email: String,
+        subscriptionPlan: SubscriptionPlan,
+        verificationToken: String,
+    ) {
+        val verificationLink = "$appUrl/verify-email?token=$verificationToken"
         val content = when (subscriptionPlan) {
-            SubscriptionPlan.BETA_TESTER -> EmailTemplates.betaTester(username, appUrl)
-            SubscriptionPlan.FREE        -> EmailTemplates.freeUser(username, appUrl)
-            SubscriptionPlan.PREMIUM     -> EmailTemplates.premiumUser(username, appUrl)
+            SubscriptionPlan.BETA_TESTER -> EmailTemplates.betaTester(username, verificationLink)
+            SubscriptionPlan.FREE        -> EmailTemplates.freeUser(username, verificationLink)
+            SubscriptionPlan.PREMIUM     -> EmailTemplates.premiumUser(username, verificationLink)
         }
         try {
             val mimeMessage = mailSender.createMimeMessage()

--- a/infrastructure/src/main/kotlin/fr/sacane/jmanager/infrastructure/spi/adapters/UserRepositoryJpaAdapter.kt
+++ b/infrastructure/src/main/kotlin/fr/sacane/jmanager/infrastructure/spi/adapters/UserRepositoryJpaAdapter.kt
@@ -73,7 +73,7 @@ class UserRepositoryJpaAdapter (
         }
     }
     @Transactional
-    override fun register(username: String, password: String, roles: Set<Role>, subscriptionPlan: SubscriptionPlan, email: String?, tosAcceptedAt: LocalDateTime?, tosVersion: String?, privacyAcceptedAt: LocalDateTime?): User? {
+    override fun register(username: String, password: String, roles: Set<Role>, subscriptionPlan: SubscriptionPlan, email: String?, tosAcceptedAt: LocalDateTime?, tosVersion: String?, privacyAcceptedAt: LocalDateTime?, emailVerified: Boolean): User? {
         return try {
             val userResource = UserResource(
                 username = username,
@@ -84,6 +84,7 @@ class UserRepositoryJpaAdapter (
                 tosAcceptedAt = tosAcceptedAt,
                 tosVersion = tosVersion,
                 privacyAcceptedAt = privacyAcceptedAt,
+                emailVerified = emailVerified,
             )
             val userResponse = userPostgresRepository.save(userResource)
             userResponse.toModel()
@@ -91,6 +92,22 @@ class UserRepositoryJpaAdapter (
             LOGGER.severe("Failed to register user: ${e.message}")
             null
         }
+    }
+
+    @Transactional
+    override fun markEmailVerified(userId: UserId): Result<Unit> {
+        val id = userId.value ?: return failure(
+            ResultState.USER_NOT_FOUND,
+            DomainError(ResultState.USER_NOT_FOUND.code, "domain.user.email_verification.user_not_found", "Identifiant utilisateur invalide")
+        )
+        val resource = userPostgresRepository.findById(id).orElse(null)
+            ?: return failure(
+                ResultState.USER_NOT_FOUND,
+                DomainError(ResultState.USER_NOT_FOUND.code, "domain.user.email_verification.user_not_found", "L'utilisateur est introuvable")
+            )
+        resource.emailVerified = true
+        userPostgresRepository.save(resource)
+        return success(Unit)
     }
     @Transactional
     override fun upsert(user: User): User? {

--- a/infrastructure/src/main/kotlin/fr/sacane/jmanager/infrastructure/spi/adapters/mail/EmailTemplates.kt
+++ b/infrastructure/src/main/kotlin/fr/sacane/jmanager/infrastructure/spi/adapters/mail/EmailTemplates.kt
@@ -9,14 +9,14 @@ internal object EmailTemplates {
 
     data class EmailContent(val subject: String, val htmlBody: String)
 
-    fun betaTester(username: String, loginUrl: String): EmailContent = EmailContent(
+    fun betaTester(username: String, verificationLink: String): EmailContent = EmailContent(
         subject = "Bienvenue dans la bêta JManager 🎉",
-        htmlBody = betaTesterHtml(username, loginUrl),
+        htmlBody = betaTesterHtml(username, verificationLink),
     )
 
-    fun freeUser(username: String, loginUrl: String): EmailContent = EmailContent(
+    fun freeUser(username: String, verificationLink: String): EmailContent = EmailContent(
         subject = "Bienvenue sur JManager !",
-        htmlBody = freeUserHtml(username, loginUrl),
+        htmlBody = freeUserHtml(username, verificationLink),
     )
 
     fun verificationEmail(verificationLink: String): EmailContent = EmailContent(
@@ -24,9 +24,9 @@ internal object EmailTemplates {
         htmlBody = verificationEmailHtml(verificationLink),
     )
 
-    fun premiumUser(username: String, loginUrl: String): EmailContent = EmailContent(
+    fun premiumUser(username: String, verificationLink: String): EmailContent = EmailContent(
         subject = "Bienvenue dans JManager Premium ✨",
-        htmlBody = premiumHtml(username, loginUrl),
+        htmlBody = premiumHtml(username, verificationLink),
     )
 
     // ─────────────────────────────────────────────────────────────────────────
@@ -49,7 +49,7 @@ internal object EmailTemplates {
         loginUrl = verificationLink,
     )
 
-    private fun betaTesterHtml(username: String, loginUrl: String): String = baseLayout(
+    private fun betaTesterHtml(username: String, verificationLink: String): String = baseLayout(
         badge = """<span style="display:inline-block;background:#822acc;color:#ffffff;padding:3px 14px;border-radius:20px;font-size:11px;font-weight:700;letter-spacing:1.5px;text-transform:uppercase;">✦ Accès Bêta Exclusif</span>""",
         body = """
             <h2 style="margin:0 0 6px;color:#1a1a2e;font-size:22px;font-weight:700;">Bonjour $username 👋</h2>
@@ -73,11 +73,11 @@ internal object EmailTemplates {
               Chaque retour que vous nous ferez — bug, suggestion, coup de cœur — sera lu et pris en compte personnellement.
             </p>
         """.trimIndent(),
-        ctaLabel = "Accéder à JManager →",
-        loginUrl = loginUrl,
+        ctaLabel = "Vérifier mon adresse e-mail →",
+        loginUrl = verificationLink,
     )
 
-    private fun freeUserHtml(username: String, loginUrl: String): String = baseLayout(
+    private fun freeUserHtml(username: String, verificationLink: String): String = baseLayout(
         badge = null,
         body = """
             <h2 style="margin:0 0 6px;color:#1a1a2e;font-size:22px;font-weight:700;">Bienvenue, $username 👋</h2>
@@ -98,11 +98,11 @@ internal object EmailTemplates {
               Notre équipe est disponible pour répondre à toutes vos questions. N'hésitez pas à nous contacter.
             </p>
         """.trimIndent(),
-        ctaLabel = "Découvrir JManager →",
-        loginUrl = loginUrl,
+        ctaLabel = "Vérifier mon adresse e-mail →",
+        loginUrl = verificationLink,
     )
 
-    private fun premiumHtml(username: String, loginUrl: String): String = baseLayout(
+    private fun premiumHtml(username: String, verificationLink: String): String = baseLayout(
         badge = """<span style="display:inline-block;background:linear-gradient(135deg,#f59e0b,#d97706);color:#ffffff;padding:3px 14px;border-radius:20px;font-size:11px;font-weight:700;letter-spacing:1.5px;text-transform:uppercase;">✦ Membre Premium</span>""",
         body = """
             <h2 style="margin:0 0 6px;color:#1a1a2e;font-size:22px;font-weight:700;">Bienvenue dans le Premium, $username ✨</h2>
@@ -126,8 +126,8 @@ internal object EmailTemplates {
               pour prendre en main votre compte, notre équipe est là pour vous.
             </p>
         """.trimIndent(),
-        ctaLabel = "Accéder à mon espace Premium →",
-        loginUrl = loginUrl,
+        ctaLabel = "Vérifier mon adresse e-mail →",
+        loginUrl = verificationLink,
     )
 
     // ─────────────────────────────────────────────────────────────────────────

--- a/infrastructure/src/main/kotlin/fr/sacane/jmanager/infrastructure/spi/adapters/mail/EmailTemplates.kt
+++ b/infrastructure/src/main/kotlin/fr/sacane/jmanager/infrastructure/spi/adapters/mail/EmailTemplates.kt
@@ -19,6 +19,11 @@ internal object EmailTemplates {
         htmlBody = freeUserHtml(username, loginUrl),
     )
 
+    fun verificationEmail(verificationLink: String): EmailContent = EmailContent(
+        subject = "Vérifiez votre adresse e-mail JManager",
+        htmlBody = verificationEmailHtml(verificationLink),
+    )
+
     fun premiumUser(username: String, loginUrl: String): EmailContent = EmailContent(
         subject = "Bienvenue dans JManager Premium ✨",
         htmlBody = premiumHtml(username, loginUrl),
@@ -27,6 +32,22 @@ internal object EmailTemplates {
     // ─────────────────────────────────────────────────────────────────────────
     // Private HTML builders
     // ─────────────────────────────────────────────────────────────────────────
+
+    private fun verificationEmailHtml(verificationLink: String): String = baseLayout(
+        badge = null,
+        body = """
+            <h2 style="margin:0 0 6px;color:#1a1a2e;font-size:22px;font-weight:700;">Confirmez votre adresse e-mail 📬</h2>
+            <p style="margin:0 0 24px;color:#6b7280;font-size:14px;line-height:1.6;">
+              Pour finaliser la création de votre compte JManager, cliquez sur le bouton ci-dessous.
+              Ce lien est valable <strong>24 heures</strong>.
+            </p>
+            <p style="margin:0 0 28px;color:#4b5563;font-size:13px;line-height:1.6;">
+              Si vous n'avez pas créé de compte, vous pouvez ignorer cet e-mail en toute sécurité.
+            </p>
+        """.trimIndent(),
+        ctaLabel = "Vérifier mon adresse e-mail →",
+        loginUrl = verificationLink,
+    )
 
     private fun betaTesterHtml(username: String, loginUrl: String): String = baseLayout(
         badge = """<span style="display:inline-block;background:#822acc;color:#ffffff;padding:3px 14px;border-radius:20px;font-size:11px;font-weight:700;letter-spacing:1.5px;text-transform:uppercase;">✦ Accès Bêta Exclusif</span>""",

--- a/infrastructure/src/main/kotlin/fr/sacane/jmanager/infrastructure/spi/adapters/utils/DatasourceMapper.kt
+++ b/infrastructure/src/main/kotlin/fr/sacane/jmanager/infrastructure/spi/adapters/utils/DatasourceMapper.kt
@@ -147,6 +147,7 @@ fun UserResource.toModel()
     projectionWindowDays = projectionWindowDays,
     subscriptionPlan = subscriptionPlan,
     consent = toConsentRecord(),
+    emailVerified = emailVerified,
 )
 fun UserResource.toModelWithSimpleBooklets()
         : User = User(
@@ -174,6 +175,7 @@ fun UserResource.toModelWithPasswords() : UserWithPassword =
             email = email,
             projectionWindowDays = projectionWindowDays,
             subscriptionPlan = subscriptionPlan,
+            emailVerified = emailVerified,
         ),
         password,
         roles,

--- a/infrastructure/src/main/kotlin/fr/sacane/jmanager/infrastructure/spi/adapters/utils/SecureTokenGeneratorAdapter.kt
+++ b/infrastructure/src/main/kotlin/fr/sacane/jmanager/infrastructure/spi/adapters/utils/SecureTokenGeneratorAdapter.kt
@@ -1,0 +1,22 @@
+package fr.sacane.jmanager.infrastructure.spi.adapters.utils
+
+import fr.sacane.jmanager.domain.hexadoc.Adapter
+import fr.sacane.jmanager.domain.hexadoc.Side
+import fr.sacane.jmanager.domain.port.output.SecureTokenGenerator
+import org.springframework.stereotype.Service
+import java.security.SecureRandom
+import java.util.Base64
+
+@Service
+@Adapter(Side.INFRASTRUCTURE)
+class SecureTokenGeneratorAdapter : SecureTokenGenerator {
+
+    private val random = SecureRandom()
+    private val encoder = Base64.getUrlEncoder().withoutPadding()
+
+    override fun generate(): String {
+        val bytes = ByteArray(32)
+        random.nextBytes(bytes)
+        return encoder.encodeToString(bytes)
+    }
+}

--- a/infrastructure/src/main/kotlin/fr/sacane/jmanager/infrastructure/spi/configuration/EmailVerificationConfiguration.kt
+++ b/infrastructure/src/main/kotlin/fr/sacane/jmanager/infrastructure/spi/configuration/EmailVerificationConfiguration.kt
@@ -1,0 +1,33 @@
+package fr.sacane.jmanager.infrastructure.spi.configuration
+
+import fr.sacane.jmanager.domain.port.output.NotificationPort
+import fr.sacane.jmanager.domain.port.output.SecureTokenGenerator
+import fr.sacane.jmanager.domain.port.output.repository.EmailVerificationTokenRepository
+import fr.sacane.jmanager.domain.usecase.EmailVerificationIssuer
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import java.time.Clock
+
+@Configuration
+@EnableConfigurationProperties(EmailVerificationProperties::class)
+class EmailVerificationConfiguration {
+
+    @Bean
+    fun systemClock(): Clock = Clock.systemUTC()
+
+    @Bean
+    fun emailVerificationIssuer(
+        tokenRepository: EmailVerificationTokenRepository,
+        secureTokenGenerator: SecureTokenGenerator,
+        notificationPort: NotificationPort,
+        clock: Clock,
+        props: EmailVerificationProperties,
+    ): EmailVerificationIssuer = EmailVerificationIssuer(
+        tokenRepository = tokenRepository,
+        secureTokenGenerator = secureTokenGenerator,
+        notificationPort = notificationPort,
+        clock = clock,
+        tokenTtl = props.tokenTtl,
+    )
+}

--- a/infrastructure/src/main/kotlin/fr/sacane/jmanager/infrastructure/spi/configuration/EmailVerificationConfiguration.kt
+++ b/infrastructure/src/main/kotlin/fr/sacane/jmanager/infrastructure/spi/configuration/EmailVerificationConfiguration.kt
@@ -1,6 +1,5 @@
 package fr.sacane.jmanager.infrastructure.spi.configuration
 
-import fr.sacane.jmanager.domain.port.output.NotificationPort
 import fr.sacane.jmanager.domain.port.output.SecureTokenGenerator
 import fr.sacane.jmanager.domain.port.output.repository.EmailVerificationTokenRepository
 import fr.sacane.jmanager.domain.usecase.EmailVerificationIssuer
@@ -20,13 +19,11 @@ class EmailVerificationConfiguration {
     fun emailVerificationIssuer(
         tokenRepository: EmailVerificationTokenRepository,
         secureTokenGenerator: SecureTokenGenerator,
-        notificationPort: NotificationPort,
         clock: Clock,
         props: EmailVerificationProperties,
     ): EmailVerificationIssuer = EmailVerificationIssuer(
         tokenRepository = tokenRepository,
         secureTokenGenerator = secureTokenGenerator,
-        notificationPort = notificationPort,
         clock = clock,
         tokenTtl = props.tokenTtl,
     )

--- a/infrastructure/src/main/kotlin/fr/sacane/jmanager/infrastructure/spi/configuration/EmailVerificationProperties.kt
+++ b/infrastructure/src/main/kotlin/fr/sacane/jmanager/infrastructure/spi/configuration/EmailVerificationProperties.kt
@@ -1,0 +1,16 @@
+package fr.sacane.jmanager.infrastructure.spi.configuration
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import java.time.Duration
+
+/**
+ * Typed configuration for the email verification flow.
+ *
+ * Bound from the `app.email-verification.*` namespace.
+ *
+ * @property tokenTtl lifetime of a verification token (ISO-8601 duration, e.g. PT24H)
+ */
+@ConfigurationProperties(prefix = "app.email-verification")
+data class EmailVerificationProperties(
+    val tokenTtl: Duration = Duration.ofHours(24),
+)

--- a/infrastructure/src/main/kotlin/fr/sacane/jmanager/infrastructure/spi/entity/EmailVerificationTokenEntity.kt
+++ b/infrastructure/src/main/kotlin/fr/sacane/jmanager/infrastructure/spi/entity/EmailVerificationTokenEntity.kt
@@ -1,0 +1,20 @@
+package fr.sacane.jmanager.infrastructure.spi.entity
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.time.LocalDateTime
+import java.util.UUID
+
+@Entity
+@Table(name = "email_verification_token")
+class EmailVerificationTokenEntity(
+    @Id
+    @Column(name = "token", nullable = false, length = 64)
+    val token: String = "",
+    @Column(name = "user_id", nullable = false)
+    val userId: UUID? = null,
+    @Column(name = "expires_at", nullable = false)
+    val expiresAt: LocalDateTime = LocalDateTime.MIN,
+)

--- a/infrastructure/src/main/kotlin/fr/sacane/jmanager/infrastructure/spi/entity/UserResource.kt
+++ b/infrastructure/src/main/kotlin/fr/sacane/jmanager/infrastructure/spi/entity/UserResource.kt
@@ -35,6 +35,8 @@ class UserResource(
     var tosVersion: String? = null,
     @Column(name = "privacy_accepted_at")
     var privacyAcceptedAt: LocalDateTime? = null,
+    @Column(name = "email_verified", nullable = false)
+    var emailVerified: Boolean = false,
     @ElementCollection(fetch = FetchType.EAGER)
     @CollectionTable(
         name = "user_role",

--- a/infrastructure/src/main/kotlin/fr/sacane/jmanager/infrastructure/spi/repositories/EmailVerificationTokenJpaRepository.kt
+++ b/infrastructure/src/main/kotlin/fr/sacane/jmanager/infrastructure/spi/repositories/EmailVerificationTokenJpaRepository.kt
@@ -1,0 +1,12 @@
+package fr.sacane.jmanager.infrastructure.spi.repositories
+
+import fr.sacane.jmanager.infrastructure.spi.entity.EmailVerificationTokenEntity
+import org.springframework.data.repository.CrudRepository
+import org.springframework.stereotype.Repository
+import java.util.UUID
+
+@Repository
+interface EmailVerificationTokenJpaRepository : CrudRepository<EmailVerificationTokenEntity, String> {
+    fun deleteByUserId(userId: UUID)
+    fun findByUserId(userId: UUID): List<EmailVerificationTokenEntity>
+}

--- a/infrastructure/src/main/resources/db/migration/V27__add_email_verification.sql
+++ b/infrastructure/src/main/resources/db/migration/V27__add_email_verification.sql
@@ -1,0 +1,21 @@
+-- Email verification state on the user aggregate.
+-- All existing rows are backfilled to true: they pre-date the verification feature
+-- and were created by an admin, so they are implicitly trusted.
+ALTER TABLE user_resource
+    ADD COLUMN IF NOT EXISTS email_verified BOOLEAN NOT NULL DEFAULT FALSE;
+
+UPDATE user_resource SET email_verified = true;
+
+-- Verification tokens: one active token per user, valid until expiresAt.
+-- ON DELETE CASCADE ensures tokens are cleaned up automatically when a user is deleted.
+CREATE TABLE IF NOT EXISTS email_verification_token (
+    token      VARCHAR(64)  NOT NULL,
+    user_id    UUID         NOT NULL,
+    expires_at TIMESTAMP    NOT NULL,
+    CONSTRAINT pk_email_verification_token PRIMARY KEY (token),
+    CONSTRAINT fk_evt_user FOREIGN KEY (user_id)
+        REFERENCES user_resource (id_user)
+        ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_evt_user_id ON email_verification_token (user_id);

--- a/infrastructure/src/test/kotlin/fr/sacane/jmanager/infrastructure/spi/adapters/EmailVerificationTokenRepositoryJpaAdapterIT.kt
+++ b/infrastructure/src/test/kotlin/fr/sacane/jmanager/infrastructure/spi/adapters/EmailVerificationTokenRepositoryJpaAdapterIT.kt
@@ -1,0 +1,102 @@
+package fr.sacane.jmanager.infrastructure.spi.adapters
+
+import fr.sacane.jmanager.domain.models.EmailVerificationToken
+import fr.sacane.jmanager.domain.models.UserId
+import fr.sacane.jmanager.infrastructure.AbstractIntegrationTest
+import fr.sacane.jmanager.infrastructure.spi.entity.UserResource
+import fr.sacane.jmanager.infrastructure.spi.repositories.EmailVerificationTokenJpaRepository
+import fr.sacane.jmanager.infrastructure.spi.repositories.UserPostgresRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import java.time.LocalDateTime
+import java.util.UUID
+
+@SpringBootTest
+class EmailVerificationTokenRepositoryJpaAdapterIT(
+    @Autowired private val adapter: EmailVerificationTokenRepositoryJpaAdapter,
+    @Autowired private val jpaRepository: EmailVerificationTokenJpaRepository,
+    @Autowired private val userPostgresRepository: UserPostgresRepository,
+) : AbstractIntegrationTest() {
+
+    private val testUserId = UUID.randomUUID()
+
+    @AfterEach
+    fun cleanup() {
+        jpaRepository.deleteAll()
+        userPostgresRepository.deleteAll()
+    }
+
+    private fun persistUser(): UserId {
+        val resource = UserResource(username = "test-verify-${testUserId}", email = "test@example.com")
+        val saved = userPostgresRepository.save(resource)
+        return UserId(saved.idUser)
+    }
+
+    private fun token(userId: UserId, raw: String = "test-token-${UUID.randomUUID()}") = EmailVerificationToken(
+        token = raw,
+        userId = userId,
+        expiresAt = LocalDateTime.now().plusHours(24),
+    )
+
+    @Test
+    fun `saved token can be retrieved by token value`() {
+        val userId = persistUser()
+        val t = token(userId, "abc123")
+
+        adapter.save(t)
+        val found = adapter.findByToken("abc123")
+
+        assertThat(found).isNotNull
+        assertThat(found!!.userId).isEqualTo(userId)
+        assertThat(found.token).isEqualTo("abc123")
+    }
+
+    @Test
+    fun `findByToken returns null for an unknown token`() {
+        val found = adapter.findByToken("does-not-exist")
+        assertThat(found).isNull()
+    }
+
+    @Test
+    fun `deleteByUserId removes all tokens for the user`() {
+        val userId = persistUser()
+        adapter.save(token(userId, "tok-1"))
+        adapter.save(token(userId, "tok-2"))
+
+        adapter.deleteByUserId(userId)
+
+        assertThat(jpaRepository.findByUserId(userId.value!!)).isEmpty()
+    }
+
+    @Test
+    fun `deleteByUserId does not affect tokens of other users`() {
+        val userId1 = persistUser()
+        val resource2 = UserResource(username = "other-user-${UUID.randomUUID()}", email = "other@example.com")
+        val saved2 = userPostgresRepository.save(resource2)
+        val userId2 = UserId(saved2.idUser)
+
+        adapter.save(token(userId1, "tok-u1"))
+        adapter.save(token(userId2, "tok-u2"))
+
+        adapter.deleteByUserId(userId1)
+
+        assertThat(jpaRepository.findByUserId(userId1.value!!)).isEmpty()
+        assertThat(jpaRepository.findByUserId(userId2.value!!)).hasSize(1)
+    }
+
+    @Test
+    fun `verified state survives a round-trip on the user`() {
+        val userId = persistUser()
+        val resource = userPostgresRepository.findById(userId.value!!).get()
+        assertThat(resource.emailVerified).isFalse()
+
+        resource.emailVerified = true
+        userPostgresRepository.save(resource)
+
+        val reloaded = userPostgresRepository.findById(userId.value!!).get()
+        assertThat(reloaded.emailVerified).isTrue()
+    }
+}


### PR DESCRIPTION
## Summary

- **Domain** — `EmailVerificationToken` model, `EmailVerificationIssuer` service, `VerifyEmailUseCase`, `ResendVerificationEmailUseCase`, `GetUserEmailVerifiedUseCase`. `User.emailVerified` added; admin-created users auto-verified, self-registered users start unverified. Two new `ResultState` codes: `EMAIL_VERIFICATION_TOKEN_EXPIRED` (6001) and `EMAIL_ALREADY_VERIFIED` (6002).
- **Infrastructure** — Flyway V27: `email_verified` column on `user_resource` (existing rows backfilled to `true`) + `email_verification_token` table with FK cascade. `SecureTokenGenerator` via `SecureRandom` base64url (32 bytes). `SpringMailNotificationAdapter` extended with `sendVerificationEmail`. Token TTL configurable via `app.email-verification.token-ttl` (default 24 h).
- **Application** — `GET /api/verify-email?token=` (public, 200/410/404), `POST /api/verify-email/resend` (authenticated, 200/409). `emailVerified` and `email` surfaced on `GET /api/user/me`. `GoneException` (410) added to `ProblemDetailHandler`.
- **Client** — `useEmailVerification` composable with 60 s resend cooldown. `useConsent` extended with `emailVerified`/`userEmail`. Sidebar amber warning badge on Paramètres tab with tooltip. Settings page email verification card with resend button. Public `/verify-email` landing page with success / expired / invalid states. 313 frontend tests green.

## Test plan

- [ ] Run `./gradlew :domain:test :infrastructure:test :application:test` — all green
- [ ] Run `pnpm test` from `client/` — 313 tests green
- [ ] Register a new user → receive verification email → click link → `emailVerified` becomes `true`, badge disappears
- [ ] Let link expire (or test with past `expiresAt`) → landing page shows "Lien expiré" + resend button
- [ ] Admin-created user logs in → no badge, no verification section in settings
- [ ] Self-registered unverified user → badge visible on Paramètres tab with tooltip, verification section visible in settings with email address shown
- [ ] Resend button: cooldown of 60 s after click, disabled during cooldown
- [ ] `POST /api/verify-email/resend` on already-verified user → 409 Conflict

## Operational note

The Flyway V27 migration backfills all existing `user_resource` rows to `email_verified = true` — no manual intervention required on deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)