### PR TITLE
feat(error-diagnostic): expose requestId, userId and bookletId in error responses

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,17 @@
 
 ## [En cours]
 
+## 2026-06-02
+
+- **Contexte de diagnostic dans les réponses d'erreur (requestId / userId / bookletId)**
+  - **Application — `RequestIdFilter`**: filtre `OncePerRequestFilter` `@Order(HIGHEST_PRECEDENCE)` enregistré au niveau conteneur servlet. Génère un UUID par requête HTTP et le place dans le MDC sous la clé `requestId`. MDC vidé dans un bloc `finally` en fin de requête.
+  - **Application — `LoggingCommandBus` / `LoggingQueryBus`**: décorateurs autour des buses Spring. Avant chaque dispatch, injectent le contexte MDC de la commande/query si elle implémente `MdcContextProvider` (`bookletId`, `transactionId`, etc.) — les clés persistent jusqu'au `MDC.clear()` du filtre, donc disponibles dans les handlers d'erreur.
+  - **Domain — `MdcContextProvider` / `MdcKeys`**: port et constantes partagés (`requestId`, `bookletId`, `transactionId`) implémentés par `FindBookletByIdQuery`, `DeleteBookletByIdCommand` et une douzaine d'autres commandes/queries à contexte identifiable.
+  - **Application — `ProblemDetailHandler`**: `buildResponse` lit le MDC complet (`getCopyOfContextMap`) et l'injecte dans `ProblemDetail.properties`; `userId` ajouté depuis `SecurityContextHolder` si l'utilisateur est authentifié. Tous les handlers d'exception (404, 403, 400, 401, 500…) exposent ainsi `requestId`, `userId`, et le contexte domaine dans `properties`.
+  - **Application — `ProblemDetailAuthenticationEntryPoint`**: remplace `HttpStatusEntryPoint` dans `SecurityConfig`. Les rejets Spring Security (401 sans contrôleur) retournent désormais un body `application/problem+json` avec `properties.requestId`.
+  - **Logback**: pattern JSON enrichi avec `%X{requestId}`, `%X{bookletId}`, `%X{transactionId}` pour corréler logs et réponses d'erreur côté support.
+  - **Tests**: `ProblemDetailHandlerTest` (unit), `DiagnosticContextIntegrationTest` (chaîne complète filter→bus→handler→JSON), `BookletControllerTest` et `SessionControllerTest` mis à jour — assertions sur `properties.requestId`, `properties.userId`, `properties.bookletId`.
+
 ## 2026-06-01
 
 - **Login par adresse e-mail (remplace le pseudonyme)**

--- a/application/src/main/kotlin/fr/sacane/jmanager/application/api/ProblemDetailAuthenticationEntryPoint.kt
+++ b/application/src/main/kotlin/fr/sacane/jmanager/application/api/ProblemDetailAuthenticationEntryPoint.kt
@@ -1,0 +1,31 @@
+package fr.sacane.jmanager.application.api
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.slf4j.MDC
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.http.ProblemDetail
+import org.springframework.security.core.AuthenticationException
+import org.springframework.security.web.AuthenticationEntryPoint
+
+class ProblemDetailAuthenticationEntryPoint(
+    private val objectMapper: ObjectMapper,
+) : AuthenticationEntryPoint {
+
+    override fun commence(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        authException: AuthenticationException,
+    ) {
+        val problemDetail = ProblemDetail.forStatus(HttpStatus.UNAUTHORIZED)
+        problemDetail.title = "Unauthorized"
+        problemDetail.detail = "Authentication is required to access this resource"
+        MDC.getCopyOfContextMap()?.forEach { (key, value) -> problemDetail.setProperty(key, value) }
+
+        response.status = HttpStatus.UNAUTHORIZED.value()
+        response.contentType = MediaType.APPLICATION_PROBLEM_JSON_VALUE
+        objectMapper.writeValue(response.writer, problemDetail)
+    }
+}

--- a/application/src/main/kotlin/fr/sacane/jmanager/application/api/ProblemDetailHandler.kt
+++ b/application/src/main/kotlin/fr/sacane/jmanager/application/api/ProblemDetailHandler.kt
@@ -1,7 +1,6 @@
 package fr.sacane.jmanager.application.api
 
 import fr.sacane.jmanager.domain.models.InvalidCurrencyException
-import fr.sacane.jmanager.domain.port.input.MdcKeys
 import fr.sacane.jmanager.domain.utils.ErrorCatalog
 import jakarta.validation.ConstraintViolationException
 import org.slf4j.LoggerFactory
@@ -40,7 +39,7 @@ class ProblemDetailHandler {
         problemDetail.detail = detail
         problemDetail.setProperty("code", code)
         problemDetail.setProperty("errorKey", errorKey ?: ErrorCatalog.keyForCode(code))
-        MDC.get(MdcKeys.REQUEST_ID)?.let { problemDetail.setProperty("requestId", it) }
+        MDC.getCopyOfContextMap()?.forEach { (key, value) -> problemDetail.setProperty(key, value) }
         currentUserIdOrNull()?.let { problemDetail.setProperty("userId", it.toString()) }
         return ResponseEntity.status(status).body(problemDetail)
     }

--- a/application/src/main/kotlin/fr/sacane/jmanager/application/api/ProblemDetailHandler.kt
+++ b/application/src/main/kotlin/fr/sacane/jmanager/application/api/ProblemDetailHandler.kt
@@ -1,14 +1,17 @@
 package fr.sacane.jmanager.application.api
 
 import fr.sacane.jmanager.domain.models.InvalidCurrencyException
+import fr.sacane.jmanager.domain.port.input.MdcKeys
 import fr.sacane.jmanager.domain.utils.ErrorCatalog
 import jakarta.validation.ConstraintViolationException
-import org.springframework.dao.OptimisticLockingFailureException
 import org.slf4j.LoggerFactory
+import org.slf4j.MDC
 import org.springframework.beans.TypeMismatchException
+import org.springframework.dao.OptimisticLockingFailureException
 import org.springframework.http.HttpStatus
 import org.springframework.http.ProblemDetail
 import org.springframework.http.ResponseEntity
+import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.MissingServletRequestParameterException
 import org.springframework.web.bind.annotation.ControllerAdvice
@@ -16,6 +19,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException
 import java.time.DateTimeException
+import java.util.UUID
 
 @ControllerAdvice(annotations = [RestController::class])
 class ProblemDetailHandler {
@@ -36,8 +40,13 @@ class ProblemDetailHandler {
         problemDetail.detail = detail
         problemDetail.setProperty("code", code)
         problemDetail.setProperty("errorKey", errorKey ?: ErrorCatalog.keyForCode(code))
+        MDC.get(MdcKeys.REQUEST_ID)?.let { problemDetail.setProperty("requestId", it) }
+        currentUserIdOrNull()?.let { problemDetail.setProperty("userId", it.toString()) }
         return ResponseEntity.status(status).body(problemDetail)
     }
+
+    private fun currentUserIdOrNull(): UUID? =
+        (SecurityContextHolder.getContext().authentication?.principal as? JmanagerUserAuthDetail)?.id
 
     private fun logException(context: String, message: String?) {
         LOGGER.error("{} : {}", context, message)

--- a/application/src/main/kotlin/fr/sacane/jmanager/application/api/RequestIdFilter.kt
+++ b/application/src/main/kotlin/fr/sacane/jmanager/application/api/RequestIdFilter.kt
@@ -1,0 +1,34 @@
+package fr.sacane.jmanager.application.api
+
+import fr.sacane.jmanager.domain.port.input.MdcKeys
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.slf4j.MDC
+import org.springframework.core.Ordered
+import org.springframework.core.annotation.Order
+import org.springframework.stereotype.Component
+import org.springframework.web.filter.OncePerRequestFilter
+import java.util.UUID
+
+// Registered at the servlet container level (outside the Spring Security filter chain).
+// Do NOT add this filter via SecurityConfig.addFilterBefore — OncePerRequestFilter prevents
+// duplicate execution within a single dispatch, but a second MDC.put() would overwrite the UUID
+// generated here, producing a different requestId in the error response than what is in the logs.
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+class RequestIdFilter : OncePerRequestFilter() {
+
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        chain: FilterChain,
+    ) {
+        MDC.put(MdcKeys.REQUEST_ID, UUID.randomUUID().toString())
+        try {
+            chain.doFilter(request, response)
+        } finally {
+            MDC.remove(MdcKeys.REQUEST_ID)
+        }
+    }
+}

--- a/application/src/main/kotlin/fr/sacane/jmanager/application/api/RequestIdFilter.kt
+++ b/application/src/main/kotlin/fr/sacane/jmanager/application/api/RequestIdFilter.kt
@@ -28,7 +28,7 @@ class RequestIdFilter : OncePerRequestFilter() {
         try {
             chain.doFilter(request, response)
         } finally {
-            MDC.remove(MdcKeys.REQUEST_ID)
+            MDC.clear()
         }
     }
 }

--- a/application/src/main/kotlin/fr/sacane/jmanager/application/api/SecurityConfig.kt
+++ b/application/src/main/kotlin/fr/sacane/jmanager/application/api/SecurityConfig.kt
@@ -1,5 +1,6 @@
 package fr.sacane.jmanager.application.api
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import fr.sacane.jmanager.domain.port.output.TokenGenerator
 import fr.sacane.jmanager.domain.port.output.UserRepository
 import fr.sacane.jmanager.application.api.session.JwtCookieAuthenticationFilter
@@ -12,7 +13,6 @@ import org.springframework.security.config.annotation.web.invoke
 import org.springframework.security.config.http.SessionCreationPolicy
 import org.springframework.security.web.SecurityFilterChain
 import org.springframework.security.web.access.AccessDeniedHandler
-import org.springframework.security.web.authentication.HttpStatusEntryPoint
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
 
 @Configuration
@@ -20,6 +20,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 class SecurityConfig(
     private val tokenGenerator: TokenGenerator,
     private val userDetailsService: UserRepository,
+    private val objectMapper: ObjectMapper,
 ) {
 
     @Bean
@@ -72,7 +73,7 @@ class SecurityConfig(
             }
             httpBasic { disable() }
             exceptionHandling {
-                authenticationEntryPoint = HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED)
+                authenticationEntryPoint = ProblemDetailAuthenticationEntryPoint(objectMapper)
                 accessDeniedHandler = AccessDeniedHandler { _, response, _ -> response.status = HttpStatus.FORBIDDEN.value() }
             }
             addFilterBefore<UsernamePasswordAuthenticationFilter>(JwtCookieAuthenticationFilter(tokenGenerator, userDetailsService))

--- a/application/src/main/kotlin/fr/sacane/jmanager/application/bus/LoggingCommandBus.kt
+++ b/application/src/main/kotlin/fr/sacane/jmanager/application/bus/LoggingCommandBus.kt
@@ -9,8 +9,10 @@ import org.springframework.stereotype.Component
 
 /**
  * Decorator around [SpringCommandBus] that:
- * 1. Injects domain context (bookletId, transactionId) into the SLF4J MDC for the duration
- *    of the dispatch when the command implements [MdcContextProvider].
+ * 1. Injects domain context (bookletId, transactionId) into the SLF4J MDC when the command
+ *    implements [MdcContextProvider]. Keys are NOT removed after dispatch — [RequestIdFilter]
+ *    calls MDC.clear() at the end of the HTTP request so the full context remains available
+ *    to error handlers (e.g. ProblemDetailHandler) if the request fails.
  * 2. Emits one INFO line per dispatch with the command name, result state, and execution time.
  *
  * ```
@@ -18,7 +20,6 @@ import org.springframework.stereotype.Component
  * COMMAND | DeleteBookletByIdCommand        | BOOKLET_NOT_FOUND |   3 ms
  * ```
  *
- * MDC is cleared in a `finally` block — no context leaks across requests.
  * No payload is logged — command fields may contain user data.
  */
 @Component
@@ -30,23 +31,18 @@ class LoggingCommandBus(
 
     override fun <R> dispatch(command: Command<R>): Result<R> {
         val name = command::class.simpleName ?: "UnknownCommand"
-        val mdcKeys = putMdcContext(command)
+        putMdcContext(command)
         val start = System.nanoTime()
-        return try {
-            val result = delegate.dispatch(command)
-            val ms = (System.nanoTime() - start) / 1_000_000
-            log.info("COMMAND | {:<50} | {:<30} | {} ms", name, result.status.name, ms)
-            result
-        } finally {
-            mdcKeys.forEach { MDC.remove(it) }
-        }
+        val result = delegate.dispatch(command)
+        val ms = (System.nanoTime() - start) / 1_000_000
+        log.info("COMMAND | {:<50} | {:<30} | {} ms", name, result.status.name, ms)
+        return result
     }
 
-    private fun putMdcContext(command: Command<*>): Set<String> {
-        if (command !is MdcContextProvider) return emptySet()
-        return command.mdcContext()
+    private fun putMdcContext(command: Command<*>) {
+        if (command !is MdcContextProvider) return
+        command.mdcContext()
             .filterValues { it.isNotBlank() }
-            .also { ctx -> ctx.forEach { (k, v) -> MDC.put(k, v) } }
-            .keys
+            .forEach { (k, v) -> MDC.put(k, v) }
     }
 }

--- a/application/src/main/kotlin/fr/sacane/jmanager/application/bus/LoggingQueryBus.kt
+++ b/application/src/main/kotlin/fr/sacane/jmanager/application/bus/LoggingQueryBus.kt
@@ -10,8 +10,10 @@ import org.springframework.stereotype.Component
 
 /**
  * Decorator around [SpringQueryBus] that:
- * 1. Injects domain context (bookletId, transactionId) into the SLF4J MDC for the duration
- *    of the dispatch when the query implements [MdcContextProvider].
+ * 1. Injects domain context (bookletId, transactionId) into the SLF4J MDC when the query
+ *    implements [MdcContextProvider]. Keys are NOT removed after dispatch — [RequestIdFilter]
+ *    calls MDC.clear() at the end of the HTTP request so the full context remains available
+ *    to error handlers (e.g. ProblemDetailHandler) if the request fails.
  * 2. Emits one INFO line per dispatch with the query name, result state, and execution time.
  *
  * ```
@@ -19,7 +21,6 @@ import org.springframework.stereotype.Component
  * QUERY  | FindBookletByIdQuery            | NOT_FOUND        |   2 ms
  * ```
  *
- * MDC is cleared in a `finally` block — no context leaks across requests.
  * No payload is logged — query fields may contain user data.
  */
 @Primary
@@ -32,23 +33,18 @@ class LoggingQueryBus(
 
     override fun <R> dispatch(query: Query<R>): Result<R> {
         val name = query::class.simpleName ?: "UnknownQuery"
-        val mdcKeys = putMdcContext(query)
+        putMdcContext(query)
         val start = System.nanoTime()
-        return try {
-            val result = delegate.dispatch(query)
-            val ms = (System.nanoTime() - start) / 1_000_000
-            log.info("QUERY  | {:<50} | {:<30} | {} ms", name, result.status.name, ms)
-            result
-        } finally {
-            mdcKeys.forEach { MDC.remove(it) }
-        }
+        val result = delegate.dispatch(query)
+        val ms = (System.nanoTime() - start) / 1_000_000
+        log.info("QUERY  | {:<50} | {:<30} | {} ms", name, result.status.name, ms)
+        return result
     }
 
-    private fun putMdcContext(query: Query<*>): Set<String> {
-        if (query !is MdcContextProvider) return emptySet()
-        return query.mdcContext()
+    private fun putMdcContext(query: Query<*>) {
+        if (query !is MdcContextProvider) return
+        query.mdcContext()
             .filterValues { it.isNotBlank() }
-            .also { ctx -> ctx.forEach { (k, v) -> MDC.put(k, v) } }
-            .keys
+            .forEach { (k, v) -> MDC.put(k, v) }
     }
 }

--- a/application/src/main/kotlin/fr/sacane/jmanager/application/configuration/JacksonConfig.kt
+++ b/application/src/main/kotlin/fr/sacane/jmanager/application/configuration/JacksonConfig.kt
@@ -38,4 +38,3 @@ class JacksonConfig {
         }
     }
 }
-

--- a/application/src/main/resources/logback-spring.xml
+++ b/application/src/main/resources/logback-spring.xml
@@ -11,8 +11,8 @@
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
       <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
         <charset>UTF-8</charset>
-        <!-- MDC context affiché en jaune uniquement quand présent -->
-        <pattern>%clr(%d{HH:mm:ss.SSS}){faint} %clr(%-5level){highlight} %clr(%-40.40logger{39}){cyan}%clr(%replace( [booklet=%X{bookletId}]){' \[booklet=\]', ''}){yellow}%clr(%replace( [tx=%X{transactionId}]){' \[tx=\]', ''}){yellow} %msg%n</pattern>
+        <!-- requestId toujours présent (filter), bookletId/transactionId conditionnels (bus) -->
+        <pattern>%clr(%d{HH:mm:ss.SSS}){faint} %clr(%-5level){highlight} %clr(%-40.40logger{39}){cyan} %clr([req=%X{requestId}]){magenta}%clr(%replace( [booklet=%X{bookletId}]){' \[booklet=\]', ''}){yellow}%clr(%replace( [tx=%X{transactionId}]){' \[tx=\]', ''}){yellow} %msg%n</pattern>
       </encoder>
     </appender>
 
@@ -58,8 +58,8 @@
 
       <encoder>
         <charset>UTF-8</charset>
-        <!-- MDC context injecté conditionnellement entre le logger et le message -->
-        <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level [%thread] %logger{36}%replace( [booklet=%X{bookletId}]){' \[booklet=\]', ''}%replace( [tx=%X{transactionId}]){' \[tx=\]', ''} - %msg%n</pattern>
+        <!-- requestId toujours présent, bookletId/transactionId conditionnels -->
+        <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level [%thread] %logger{36} [req=%X{requestId}]%replace( [booklet=%X{bookletId}]){' \[booklet=\]', ''}%replace( [tx=%X{transactionId}]){' \[tx=\]', ''} - %msg%n</pattern>
       </encoder>
 
       <!-- Filtre : INFO et au-dessus uniquement -->
@@ -86,8 +86,8 @@
 
       <encoder>
         <charset>UTF-8</charset>
-        <!-- MDC context + stack trace complète sur les erreurs -->
-        <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level [%thread] %logger{36}%replace( [booklet=%X{bookletId}]){' \[booklet=\]', ''}%replace( [tx=%X{transactionId}]){' \[tx=\]', ''} - %msg%n%ex{full}</pattern>
+        <!-- requestId toujours présent, bookletId/transactionId conditionnels, stack trace complète -->
+        <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level [%thread] %logger{36} [req=%X{requestId}]%replace( [booklet=%X{bookletId}]){' \[booklet=\]', ''}%replace( [tx=%X{transactionId}]){' \[tx=\]', ''} - %msg%n%ex{full}</pattern>
       </encoder>
 
       <!-- Filtre strict : ERROR uniquement -->
@@ -136,7 +136,7 @@
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
       <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
         <charset>UTF-8</charset>
-        <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level [%thread] %logger{36}%replace( [booklet=%X{bookletId}]){' \[booklet=\]', ''}%replace( [tx=%X{transactionId}]){' \[tx=\]', ''} - %msg%n</pattern>
+        <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level [%thread] %logger{36} [req=%X{requestId}]%replace( [booklet=%X{bookletId}]){' \[booklet=\]', ''}%replace( [tx=%X{transactionId}]){' \[tx=\]', ''} - %msg%n</pattern>
       </encoder>
     </appender>
 

--- a/application/src/test/kotlin/fr/sacane/jmanager/application/api/BookletControllerTest.kt
+++ b/application/src/test/kotlin/fr/sacane/jmanager/application/api/BookletControllerTest.kt
@@ -21,6 +21,7 @@ import io.restassured.module.kotlin.extensions.Given
 import io.restassured.module.kotlin.extensions.Then
 import io.restassured.module.kotlin.extensions.When
 import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.Matchers.matchesPattern
 import java.time.YearMonth
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -31,6 +32,8 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.web.server.LocalServerPort
 import org.springframework.test.context.TestPropertySource
 import java.time.LocalDate
+
+private const val UUID_PATTERN = "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource(locations = ["classpath:application-test.properties"])
@@ -65,7 +68,7 @@ class BookletControllerTest(
             }
         }
         @Test
-        fun `Should return invalid request 400 when trying to save more than 6 booklets`() {
+        fun `Should return invalid request 400 with requestId and userId when trying to save more than 6 booklets`() {
             val body = BookletBookingRequest("test7", 1000.toDouble(), "€")
             val booklets = mutableListOf<Booklet>()
             repeat(6) {
@@ -88,11 +91,13 @@ class BookletControllerTest(
                 post("/api/booklet")
             } Then {
                 statusCode(400)
+                body("properties.requestId", matchesPattern(UUID_PATTERN))
+                body("properties.userId", equalTo(user!!.id.value.toString()))
             }
         }
 
         @Test
-        fun `Should send 400 with bad currency request`() {
+        fun `Should send 400 with requestId and userId on bad currency request`() {
             val body = BookletBookingRequest("test", 1000.toDouble(), "ERR")
             Given {
                 port(port)
@@ -103,6 +108,8 @@ class BookletControllerTest(
                 post("/api/booklet")
             } Then {
                 statusCode(400)
+                body("properties.requestId", matchesPattern(UUID_PATTERN))
+                body("properties.userId", equalTo(user!!.id.value.toString()))
             }
         }
     }
@@ -136,7 +143,7 @@ class BookletControllerTest(
         }
 
         @Test
-        fun `Delete booklet from an ID of a booklet that does not exists should return 404`() {
+        fun `Delete booklet from an ID of a booklet that does not exists should return 404 with requestId and userId`() {
             Given {
                 port(port)
                 cookie("token", token)
@@ -145,6 +152,8 @@ class BookletControllerTest(
                 delete("/api/booklet/231")
             } Then {
                 statusCode(404)
+                body("properties.requestId", matchesPattern(UUID_PATTERN))
+                body("properties.userId", equalTo(user!!.id.value.toString()))
             }
         }
         @Test

--- a/application/src/test/kotlin/fr/sacane/jmanager/application/api/DiagnosticContextIntegrationTest.kt
+++ b/application/src/test/kotlin/fr/sacane/jmanager/application/api/DiagnosticContextIntegrationTest.kt
@@ -1,0 +1,134 @@
+package fr.sacane.jmanager.application.api
+
+import fr.sacane.jmanager.application.api.setup.BookletStateTestAdapter
+import io.restassured.module.kotlin.extensions.Extract
+import io.restassured.module.kotlin.extensions.Given
+import io.restassured.module.kotlin.extensions.Then
+import io.restassured.module.kotlin.extensions.When
+import org.hamcrest.CoreMatchers.nullValue
+import org.hamcrest.Matchers.matchesPattern
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.web.server.LocalServerPort
+import org.springframework.test.context.TestPropertySource
+import java.util.UUID
+
+private const val UUID_PATTERN = "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+
+/**
+ * Validates the full diagnostic context chain:
+ * RequestIdFilter → Spring Security → Bus (MDC) → Controller → ProblemDetailHandler → JSON response.
+ *
+ * When a user reports a bug, they copy the fields from the error toast and send them to support.
+ * Support uses:
+ *   - requestId → grep /var/log/jmanager/app.log to find all lines for that specific request
+ *   - bookletId/transactionId → already in the same log lines via MDC (LoggingBus)
+ *   - userId → look up the user and their data in the database
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@TestPropertySource(locations = ["classpath:application-test.properties"])
+class DiagnosticContextIntegrationTest(
+    @LocalServerPort val port: Int,
+    @Autowired val bookletStateAdapter: BookletStateTestAdapter,
+) : AuthenticatedUserTest() {
+
+    @AfterEach
+    fun clear() {
+        bookletStateAdapter.clear()
+    }
+
+    @Nested
+    inner class RequestIdInErrorResponse {
+
+        @Test
+        fun `authenticated 404 includes requestId, bookletId and userId`() {
+            val bookletId = UUID.randomUUID().toString()
+
+            Given {
+                port(port)
+                cookie("token", token)
+            } When {
+                get("/api/booklet/$bookletId")
+            } Then {
+                statusCode(404)
+                body("properties.requestId", matchesPattern(UUID_PATTERN))
+                body("properties.bookletId", matchesPattern(UUID_PATTERN))
+                body("properties.userId", matchesPattern(UUID_PATTERN))
+            }
+        }
+
+        @Test
+        fun `authenticated 404 bookletId in response matches the id from the request path`() {
+            val bookletId = UUID.randomUUID().toString()
+
+            Given {
+                port(port)
+                cookie("token", token)
+            } When {
+                get("/api/booklet/$bookletId")
+            } Then {
+                statusCode(404)
+                body("properties.bookletId", org.hamcrest.CoreMatchers.equalTo(bookletId))
+            }
+        }
+
+        @Test
+        fun `authenticated 404 userId in response matches the authenticated user`() {
+            Given {
+                port(port)
+                cookie("token", token)
+            } When {
+                get("/api/booklet/${UUID.randomUUID()}")
+            } Then {
+                statusCode(404)
+                body("properties.userId", org.hamcrest.CoreMatchers.equalTo(user!!.id.value.toString()))
+            }
+        }
+
+        @Test
+        fun `unauthenticated error includes requestId but no userId`() {
+            Given {
+                port(port)
+                header("Content-Type", "application/json")
+                body("""{"email":"ghost@example.com","password":"test"}""")
+            } When {
+                post("/api/user/auth")
+            } Then {
+                statusCode(404)
+                body("properties.requestId", matchesPattern(UUID_PATTERN))
+                body("properties.userId", nullValue())
+            }
+        }
+
+        @Test
+        fun `two distinct failing requests produce different requestIds`() {
+            val firstId = Given {
+                port(port)
+                cookie("token", token)
+            } When {
+                get("/api/booklet/${UUID.randomUUID()}")
+            } Then {
+                statusCode(404)
+            } Extract {
+                path<String>("properties.requestId")
+            }
+
+            val secondId = Given {
+                port(port)
+                cookie("token", token)
+            } When {
+                get("/api/booklet/${UUID.randomUUID()}")
+            } Then {
+                statusCode(404)
+            } Extract {
+                path<String>("properties.requestId")
+            }
+
+            assertNotEquals(firstId, secondId)
+        }
+    }
+}

--- a/application/src/test/kotlin/fr/sacane/jmanager/application/api/ProblemDetailHandlerTest.kt
+++ b/application/src/test/kotlin/fr/sacane/jmanager/application/api/ProblemDetailHandlerTest.kt
@@ -1,21 +1,34 @@
 package fr.sacane.jmanager.application.api
 
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
+import org.slf4j.MDC
 import org.springframework.http.HttpStatus
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.web.bind.MissingServletRequestParameterException
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException
 import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.beans.TypeMismatchException
 import java.time.DateTimeException
+import java.util.UUID
 import org.mockito.Mockito
+import fr.sacane.jmanager.domain.models.InvalidCurrencyException
+import fr.sacane.jmanager.domain.models.Role
+import fr.sacane.jmanager.domain.port.input.MdcKeys
 import fr.sacane.jmanager.domain.utils.ErrorCatalog
 import fr.sacane.jmanager.domain.utils.ResultState
-import fr.sacane.jmanager.domain.models.InvalidCurrencyException
 
 class ProblemDetailHandlerTest {
 
     private val handler = ProblemDetailHandler()
+
+    @AfterEach
+    fun cleanup() {
+        MDC.remove(MdcKeys.REQUEST_ID)
+        SecurityContextHolder.clearContext()
+    }
 
     @Test
     fun `handle missing parameter returns bad request with code 65`() {
@@ -240,6 +253,42 @@ class ProblemDetailHandlerTest {
         assertThat(pd.detail).isEqualTo("Access denied")
         assertThat(pd.properties!!["code"]).isEqualTo(777)
         assertThat(pd.properties!!["errorKey"]).isEqualTo("unknown.error")
+    }
+
+    @Test
+    fun `requestId from MDC is included in error response`() {
+        val id = UUID.randomUUID().toString()
+        MDC.put(MdcKeys.REQUEST_ID, id)
+
+        val resp = handler.handleNotFoundException(NotFoundException(404, "not found"))
+
+        assertThat(resp.body!!.properties!!["requestId"]).isEqualTo(id)
+    }
+
+    @Test
+    fun `requestId is absent when MDC has no entry`() {
+        val resp = handler.handleNotFoundException(NotFoundException(404, "not found"))
+
+        assertThat(resp.body!!.properties!!).doesNotContainKey("requestId")
+    }
+
+    @Test
+    fun `userId from SecurityContext is included when authenticated`() {
+        val userId = UUID.randomUUID()
+        val principal = JmanagerUserAuthDetail(id = userId, username = "alice", role = setOf(Role.USER), token = "tok")
+        val auth = UsernamePasswordAuthenticationToken(principal, null, emptyList())
+        SecurityContextHolder.getContext().authentication = auth
+
+        val resp = handler.handleNotFoundException(NotFoundException(404, "not found"))
+
+        assertThat(resp.body!!.properties!!["userId"]).isEqualTo(userId.toString())
+    }
+
+    @Test
+    fun `userId is absent when unauthenticated`() {
+        val resp = handler.handleNotFoundException(NotFoundException(404, "not found"))
+
+        assertThat(resp.body!!.properties!!).doesNotContainKey("userId")
     }
 
     @Test

--- a/application/src/test/kotlin/fr/sacane/jmanager/application/api/ProblemDetailHandlerTest.kt
+++ b/application/src/test/kotlin/fr/sacane/jmanager/application/api/ProblemDetailHandlerTest.kt
@@ -26,7 +26,7 @@ class ProblemDetailHandlerTest {
 
     @AfterEach
     fun cleanup() {
-        MDC.remove(MdcKeys.REQUEST_ID)
+        MDC.clear()
         SecurityContextHolder.clearContext()
     }
 
@@ -256,20 +256,24 @@ class ProblemDetailHandlerTest {
     }
 
     @Test
-    fun `requestId from MDC is included in error response`() {
-        val id = UUID.randomUUID().toString()
-        MDC.put(MdcKeys.REQUEST_ID, id)
+    fun `all MDC entries are included in error response`() {
+        val requestId = UUID.randomUUID().toString()
+        val bookletId = UUID.randomUUID().toString()
+        MDC.put(MdcKeys.REQUEST_ID, requestId)
+        MDC.put(MdcKeys.BOOKLET_ID, bookletId)
 
         val resp = handler.handleNotFoundException(NotFoundException(404, "not found"))
 
-        assertThat(resp.body!!.properties!!["requestId"]).isEqualTo(id)
+        assertThat(resp.body!!.properties!!["requestId"]).isEqualTo(requestId)
+        assertThat(resp.body!!.properties!!["bookletId"]).isEqualTo(bookletId)
     }
 
     @Test
-    fun `requestId is absent when MDC has no entry`() {
+    fun `no MDC properties in response when MDC is empty`() {
         val resp = handler.handleNotFoundException(NotFoundException(404, "not found"))
 
         assertThat(resp.body!!.properties!!).doesNotContainKey("requestId")
+        assertThat(resp.body!!.properties!!).doesNotContainKey("bookletId")
     }
 
     @Test

--- a/application/src/test/kotlin/fr/sacane/jmanager/application/api/SessionControllerTest.kt
+++ b/application/src/test/kotlin/fr/sacane/jmanager/application/api/SessionControllerTest.kt
@@ -21,6 +21,8 @@ import io.restassured.module.kotlin.extensions.Then
 import io.restassured.module.kotlin.extensions.When
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.CoreMatchers.notNullValue
+import org.hamcrest.CoreMatchers.nullValue
+import org.hamcrest.Matchers.matchesPattern
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Nested
@@ -31,6 +33,8 @@ import org.springframework.boot.test.web.server.LocalServerPort
 import org.springframework.test.context.TestPropertySource
 import java.util.UUID
 
+
+private const val UUID_PATTERN = "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource(locations = ["classpath:application-test.properties"])
@@ -76,6 +80,8 @@ class SessionControllerTest(
                 post("/api/user/auth")
             } Then {
                 statusCode(404)
+                body("properties.requestId", matchesPattern(UUID_PATTERN))
+                body("properties.userId", nullValue())
             }
         }
 
@@ -89,6 +95,8 @@ class SessionControllerTest(
                 post("/api/user/auth")
             } Then {
                 statusCode(403)
+                body("properties.requestId", matchesPattern(UUID_PATTERN))
+                body("properties.userId", nullValue())
             }
         }
 
@@ -102,6 +110,8 @@ class SessionControllerTest(
                 post("/api/user/auth")
             } Then {
                 statusCode(400)
+                body("properties.requestId", matchesPattern(UUID_PATTERN))
+                body("properties.userId", nullValue())
             }
         }
 
@@ -286,6 +296,8 @@ class SessionControllerTest(
                 put("/api/user/settings")
             } Then {
                 statusCode(400)
+                body("properties.requestId", matchesPattern(UUID_PATTERN))
+                body("properties.userId", equalTo(user!!.id.value.toString()))
             }
         }
 
@@ -357,6 +369,8 @@ class SessionControllerTest(
                 put("/api/user/settings")
             } Then {
                 statusCode(403)
+                body("properties.requestId", matchesPattern(UUID_PATTERN))
+                body("properties.userId", equalTo(user!!.id.value.toString()))
             }
         }
 
@@ -539,6 +553,8 @@ class SessionControllerTest(
                 post("/api/user/consent")
             } Then {
                 statusCode(401)
+                body("properties.requestId", matchesPattern(UUID_PATTERN))
+                body("properties.userId", nullValue())
             }
         }
 

--- a/client/app.vue
+++ b/client/app.vue
@@ -14,7 +14,7 @@ tryOnBeforeMount(() => {
   <div class="w-full h-full">
     <NuxtLoadingIndicator />
     <NuxtLayout>
-      <Toast />
+      <AppToast />
       <NuxtPage />
     </NuxtLayout>
   </div>

--- a/client/components/AppToast.vue
+++ b/client/components/AppToast.vue
@@ -1,0 +1,76 @@
+<script setup lang="ts">
+import type { DiagnosticContext } from '~/utils/errorCodeMap'
+import { buildDiagnosticText } from '~/utils/errorCodeMap'
+
+interface ToastMessage extends DiagnosticContext {
+  summary?: string
+  detail?: string
+  severity?: string
+}
+
+type CopyState = 'idle' | 'copied' | 'error'
+
+const copyStates = reactive<Record<string, CopyState>>({})
+
+const severityIcon: Record<string, string> = {
+  success: 'pi pi-check-circle',
+  info: 'pi pi-info-circle',
+  warn: 'pi pi-exclamation-triangle',
+  error: 'pi pi-times-circle',
+}
+
+const severityColor: Record<string, string> = {
+  success: 'text-green-400',
+  info: 'text-blue-400',
+  warn: 'text-yellow-400',
+  error: 'text-red-400',
+}
+
+function copyButtonLabel(requestId: string): string {
+  const state = copyStates[requestId] ?? 'idle'
+  if (state === 'copied') return 'Copié !'
+  if (state === 'error') return 'Échec de la copie'
+  return 'Copier les infos de débogage'
+}
+
+async function copyDiagnostic(msg: ToastMessage) {
+  if (!msg.requestId) return
+  const requestId = msg.requestId
+  const text = buildDiagnosticText(msg)
+  try {
+    await navigator.clipboard.writeText(text)
+    copyStates[requestId] = 'copied'
+  }
+  catch {
+    copyStates[requestId] = 'error'
+  }
+  setTimeout(() => { delete copyStates[requestId] }, 2000)
+}
+</script>
+
+<template>
+  <Toast>
+    <template #message="{ message: rawMsg }">
+      <template v-for="msg in [(rawMsg as ToastMessage)]" :key="0">
+        <div class="flex items-start gap-2.5 flex-1 min-w-0 py-0.5">
+          <i
+            v-if="msg.severity && severityIcon[msg.severity]"
+            :class="[severityIcon[msg.severity], severityColor[msg.severity], 'text-lg mt-0.5 shrink-0']"
+          />
+          <div class="flex flex-col gap-1 flex-1 min-w-0">
+            <span class="font-semibold text-sm leading-snug">{{ msg.summary }}</span>
+            <span class="text-xs opacity-80 leading-relaxed">{{ msg.detail }}</span>
+            <button
+              v-if="msg.requestId"
+              class="self-start mt-1 text-xs font-medium px-2 py-1 rounded border border-white/30 bg-white/10 hover:bg-white/20 transition-colors duration-150 cursor-pointer"
+              :aria-label="copyButtonLabel(msg.requestId)"
+              @click="copyDiagnostic(msg)"
+            >
+              {{ copyButtonLabel(msg.requestId) }}
+            </button>
+          </div>
+        </div>
+      </template>
+    </template>
+  </Toast>
+</template>

--- a/client/composables/useAuth.ts
+++ b/client/composables/useAuth.ts
@@ -1,6 +1,7 @@
 import type { AxiosError } from 'axios'
 import axios from 'axios'
 import { jwtDecode } from 'jwt-decode'
+import { extractErrorCode } from '~/utils/errorCodeMap'
 
 export interface UserAuth {
   email: string
@@ -142,7 +143,7 @@ export default function useAuth() {
     if (axios.isAxiosError(error)) {
       const axiosError = error as AxiosError<any, any>
       const httpStatus = axiosError.response?.status
-      const domainCode = axiosError.response?.data?.code
+      const domainCode = extractErrorCode(axiosError.response?.data)
       const legacyStatus = axiosError.response?.data?.status
 
       if (domainCode === 1 || legacyStatus === 307) {

--- a/client/composables/useJToast.ts
+++ b/client/composables/useJToast.ts
@@ -1,5 +1,5 @@
 import type { AxiosError } from 'axios'
-import { extractErrorCode, getErrorMessageByCode } from '~/utils/errorCodeMap'
+import { extractDiagnosticContext, getErrorMessageByCode } from '~/utils/errorCodeMap'
 
 export default function useJToast() {
   const toast = useToast()
@@ -29,14 +29,18 @@ export default function useJToast() {
       life: 3000,
     })
   }
-  function errorAxios(axiosError: AxiosError, title: string = 'Erreur') {
-    const code = extractErrorCode(axiosError.response?.data)
+  function errorAxios(axiosError: AxiosError, title?: string) {
+    const data = axiosError.response?.data
+    const { requestId, userId, code } = extractDiagnosticContext(data)
     const mappedError = getErrorMessageByCode(code)
     toast.add({
       severity: 'error',
-      summary: title === 'Erreur' ? mappedError.summary : title,
+      summary: title ?? mappedError.summary,
       detail: mappedError.detail,
-      life: 3000,
+      life: requestId ? 8000 : 3000,
+      requestId,
+      userId,
+      code,
     })
   }
   return { success, warn, error, errorAxios }

--- a/client/composables/useQuery.ts
+++ b/client/composables/useQuery.ts
@@ -1,5 +1,6 @@
 import type { AxiosError } from 'axios'
 import axios from 'axios'
+import { extractErrorCode } from '~/utils/errorCodeMap'
 import useAuth from './useAuth'
 
 type RequestExecutor<T> = () => Promise<{ data: T }>
@@ -86,7 +87,7 @@ export default function useQuery() {
     if (axios.isAxiosError(error)) {
       const axiosError = error as AxiosError<any, any>
       const status = axiosError.response?.status
-      const domainCode = axiosError.response?.data?.code
+      const domainCode = extractErrorCode(axiosError.response?.data)
 
       if (domainCode === 1 && request) {
         const refreshed = await tryRefresh({ redirectOnFailure: false })

--- a/client/tests/components/AppToast.spec.ts
+++ b/client/tests/components/AppToast.spec.ts
@@ -1,0 +1,173 @@
+import { mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import AppToast from '../../components/AppToast.vue'
+
+const writeTextMock = vi.fn().mockResolvedValue(undefined)
+
+Object.defineProperty(globalThis, 'navigator', {
+  configurable: true,
+  value: { clipboard: { writeText: writeTextMock } },
+})
+
+function makeToastStub(message: Record<string, unknown>) {
+  return {
+    name: 'Toast',
+    setup(_: unknown, { slots }: { slots: Record<string, ((p: unknown) => unknown) | undefined> }) {
+      return () => slots.message?.({ message })
+    },
+  }
+}
+
+describe('components/AppToast', () => {
+  beforeEach(() => {
+    writeTextMock.mockClear()
+    writeTextMock.mockResolvedValue(undefined)
+  })
+
+  it('renders summary and detail from the message slot', () => {
+    const wrapper = mount(AppToast, {
+      global: {
+        stubs: {
+          Toast: makeToastStub({ summary: 'Erreur', detail: 'Quelque chose a échoué' }),
+        },
+      },
+    })
+
+    expect(wrapper.text()).toContain('Erreur')
+    expect(wrapper.text()).toContain('Quelque chose a échoué')
+  })
+
+  it('renders severity icon when severity is provided', () => {
+    const wrapper = mount(AppToast, {
+      global: {
+        stubs: {
+          Toast: makeToastStub({ summary: 'Erreur', detail: 'Échec', severity: 'error' }),
+        },
+      },
+    })
+
+    expect(wrapper.find('i.pi.pi-times-circle').exists()).toBe(true)
+  })
+
+  it('renders correct icon class per severity', () => {
+    const cases: Array<{ severity: string; expectedClass: string }> = [
+      { severity: 'success', expectedClass: 'pi-check-circle' },
+      { severity: 'info', expectedClass: 'pi-info-circle' },
+      { severity: 'warn', expectedClass: 'pi-exclamation-triangle' },
+      { severity: 'error', expectedClass: 'pi-times-circle' },
+    ]
+
+    for (const { severity, expectedClass } of cases) {
+      const wrapper = mount(AppToast, {
+        global: {
+          stubs: {
+            Toast: makeToastStub({ summary: 'Msg', detail: 'Détail', severity }),
+          },
+        },
+      })
+      expect(wrapper.find(`i.${expectedClass}`).exists()).toBe(true)
+    }
+  })
+
+  it('does not render icon when severity is absent', () => {
+    const wrapper = mount(AppToast, {
+      global: {
+        stubs: {
+          Toast: makeToastStub({ summary: 'Erreur', detail: 'Échec' }),
+        },
+      },
+    })
+
+    expect(wrapper.find('i').exists()).toBe(false)
+  })
+
+  it('shows copy button when requestId is present', () => {
+    const wrapper = mount(AppToast, {
+      global: {
+        stubs: {
+          Toast: makeToastStub({ summary: 'Erreur', detail: 'Échec', requestId: 'req-abc' }),
+        },
+      },
+    })
+
+    expect(wrapper.find('button').exists()).toBe(true)
+    expect(wrapper.find('button').text()).toBe('Copier les infos de débogage')
+  })
+
+  it('does not show copy button when requestId is absent', () => {
+    const wrapper = mount(AppToast, {
+      global: {
+        stubs: {
+          Toast: makeToastStub({ summary: 'Erreur', detail: 'Échec' }),
+        },
+      },
+    })
+
+    expect(wrapper.find('button').exists()).toBe(false)
+  })
+
+  it('calls clipboard.writeText with diagnostic text on button click', async () => {
+    const wrapper = mount(AppToast, {
+      global: {
+        stubs: {
+          Toast: makeToastStub({ summary: 'Erreur', detail: 'Échec', requestId: 'req-abc', userId: 'user-xyz', code: 500 }),
+        },
+      },
+    })
+
+    await wrapper.find('button').trigger('click')
+    await wrapper.vm.$nextTick()
+
+    expect(writeTextMock).toHaveBeenCalledOnce()
+    const text: string = writeTextMock.mock.calls[0][0]
+    expect(text).toContain('requestId: req-abc')
+    expect(text).toContain('userId: user-xyz')
+    expect(text).toContain('code: 500')
+  })
+
+  it('changes button label to "Copié !" after successful copy', async () => {
+    vi.useFakeTimers()
+    const wrapper = mount(AppToast, {
+      global: {
+        stubs: {
+          Toast: makeToastStub({ summary: 'Erreur', detail: 'Échec', requestId: 'req-abc' }),
+        },
+      },
+    })
+
+    await wrapper.find('button').trigger('click')
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.find('button').text()).toBe('Copié !')
+
+    vi.advanceTimersByTime(2000)
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.find('button').text()).toBe('Copier les infos de débogage')
+    vi.useRealTimers()
+  })
+
+  it('shows "Échec de la copie" when clipboard write fails', async () => {
+    vi.useFakeTimers()
+    writeTextMock.mockRejectedValueOnce(new Error('Permission denied'))
+
+    const wrapper = mount(AppToast, {
+      global: {
+        stubs: {
+          Toast: makeToastStub({ summary: 'Erreur', detail: 'Échec', requestId: 'req-abc' }),
+        },
+      },
+    })
+
+    await wrapper.find('button').trigger('click')
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.find('button').text()).toBe('Échec de la copie')
+
+    vi.advanceTimersByTime(2000)
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.find('button').text()).toBe('Copier les infos de débogage')
+    vi.useRealTimers()
+  })
+})

--- a/client/tests/unit/errorCodeMap.spec.ts
+++ b/client/tests/unit/errorCodeMap.spec.ts
@@ -1,5 +1,10 @@
-import { describe, expect, it } from 'vitest'
-import { extractErrorCode, getErrorMessageByCode } from '../../utils/errorCodeMap'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  buildDiagnosticText,
+  extractDiagnosticContext,
+  extractErrorCode,
+  getErrorMessageByCode,
+} from '../../utils/errorCodeMap'
 
 describe('utils/errorCodeMap', () => {
   it('extracts code from problem detail properties', () => {
@@ -28,6 +33,61 @@ describe('utils/errorCodeMap', () => {
     expect(getErrorMessageByCode(999999)).toEqual({
       summary: 'Erreur',
       detail: 'Une erreur inconnue est survenue.',
+    })
+  })
+
+  describe('extractDiagnosticContext', () => {
+    it('extracts requestId, userId and code from payload', () => {
+      const ctx = extractDiagnosticContext({ code: 404, requestId: 'req-abc', userId: 'user-xyz' })
+      expect(ctx).toEqual({ requestId: 'req-abc', userId: 'user-xyz', code: 404 })
+    })
+
+    it('returns empty object for null payload', () => {
+      expect(extractDiagnosticContext(null)).toEqual({})
+    })
+
+    it('omits requestId when not a string', () => {
+      const ctx = extractDiagnosticContext({ requestId: 42 })
+      expect(ctx.requestId).toBeUndefined()
+    })
+
+    it('omits userId when absent', () => {
+      const ctx = extractDiagnosticContext({ requestId: 'req-123' })
+      expect(ctx.userId).toBeUndefined()
+    })
+  })
+
+  describe('buildDiagnosticText', () => {
+    beforeEach(() => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date('2026-06-01T12:00:00.000Z'))
+    })
+
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    it('includes all fields when all are present', () => {
+      const text = buildDiagnosticText({ requestId: 'req-abc', userId: 'user-xyz', code: 404 })
+      expect(text).toContain('requestId: req-abc')
+      expect(text).toContain('userId: user-xyz')
+      expect(text).toContain('code: 404')
+      expect(text).toContain('date: 2026-06-01T12:00:00.000Z')
+    })
+
+    it('omits userId line when undefined', () => {
+      const text = buildDiagnosticText({ requestId: 'req-abc', code: 500 })
+      expect(text).not.toContain('userId')
+    })
+
+    it('omits code line when undefined', () => {
+      const text = buildDiagnosticText({ requestId: 'req-abc' })
+      expect(text).not.toContain('code:')
+    })
+
+    it('always includes date', () => {
+      const text = buildDiagnosticText({})
+      expect(text).toContain('date:')
     })
   })
 })

--- a/client/tests/unit/errorCodeMap.spec.ts
+++ b/client/tests/unit/errorCodeMap.spec.ts
@@ -37,9 +37,26 @@ describe('utils/errorCodeMap', () => {
   })
 
   describe('extractDiagnosticContext', () => {
-    it('extracts requestId, userId and code from payload', () => {
+    it('extracts requestId, userId and code from root payload', () => {
       const ctx = extractDiagnosticContext({ code: 404, requestId: 'req-abc', userId: 'user-xyz' })
       expect(ctx).toEqual({ requestId: 'req-abc', userId: 'user-xyz', code: 404 })
+    })
+
+    it('extracts requestId and userId from nested properties (Spring ProblemDetail format)', () => {
+      const ctx = extractDiagnosticContext({
+        properties: { code: 1001, requestId: 'req-nested', userId: 'user-nested' },
+      })
+      expect(ctx.requestId).toBe('req-nested')
+      expect(ctx.userId).toBe('user-nested')
+      expect(ctx.code).toBe(1001)
+    })
+
+    it('prefers root-level requestId over properties when both present', () => {
+      const ctx = extractDiagnosticContext({
+        requestId: 'root-id',
+        properties: { requestId: 'nested-id' },
+      })
+      expect(ctx.requestId).toBe('root-id')
     })
 
     it('returns empty object for null payload', () => {

--- a/client/tests/unit/useJToast.spec.ts
+++ b/client/tests/unit/useJToast.spec.ts
@@ -64,7 +64,7 @@ describe('composables/useJToast', () => {
     }))
   })
 
-  it('passes requestId and userId in toast message when present in response', () => {
+  it('passes requestId and userId in toast message when present at root level', () => {
     const { errorAxios } = useJToast()
     const axiosError = {
       response: {
@@ -77,6 +77,24 @@ describe('composables/useJToast', () => {
     expect(add).toHaveBeenCalledWith(expect.objectContaining({
       requestId: 'req-abc-123',
       userId: 'user-xyz-456',
+    }))
+  })
+
+  it('passes requestId and userId from nested properties (Spring ProblemDetail format)', () => {
+    const { errorAxios } = useJToast()
+    const axiosError = {
+      response: {
+        data: {
+          properties: { code: 1001, requestId: 'req-from-props', userId: 'user-from-props' },
+        },
+      },
+    } as any
+
+    errorAxios(axiosError)
+
+    expect(add).toHaveBeenCalledWith(expect.objectContaining({
+      requestId: 'req-from-props',
+      userId: 'user-from-props',
     }))
   })
 

--- a/client/tests/unit/useJToast.spec.ts
+++ b/client/tests/unit/useJToast.spec.ts
@@ -63,4 +63,55 @@ describe('composables/useJToast', () => {
       detail: 'Une erreur inconnue est survenue.',
     }))
   })
+
+  it('passes requestId and userId in toast message when present in response', () => {
+    const { errorAxios } = useJToast()
+    const axiosError = {
+      response: {
+        data: { code: 500, requestId: 'req-abc-123', userId: 'user-xyz-456' },
+      },
+    } as any
+
+    errorAxios(axiosError)
+
+    expect(add).toHaveBeenCalledWith(expect.objectContaining({
+      requestId: 'req-abc-123',
+      userId: 'user-xyz-456',
+    }))
+  })
+
+  it('uses 8000ms life when requestId is present', () => {
+    const { errorAxios } = useJToast()
+    const axiosError = {
+      response: { data: { code: 500, requestId: 'req-abc' } },
+    } as any
+
+    errorAxios(axiosError)
+
+    expect(add).toHaveBeenCalledWith(expect.objectContaining({ life: 8000 }))
+  })
+
+  it('uses 3000ms life when requestId is absent', () => {
+    const { errorAxios } = useJToast()
+    const axiosError = {
+      response: { data: { code: 404 } },
+    } as any
+
+    errorAxios(axiosError)
+
+    expect(add).toHaveBeenCalledWith(expect.objectContaining({ life: 3000 }))
+  })
+
+  it('does not include requestId in toast message when absent', () => {
+    const { errorAxios } = useJToast()
+    const axiosError = {
+      response: { data: { code: 404 } },
+    } as any
+
+    errorAxios(axiosError)
+
+    const call = add.mock.calls[0][0]
+    expect(call.requestId).toBeUndefined()
+    expect(call.userId).toBeUndefined()
+  })
 })

--- a/client/utils/errorCodeMap.ts
+++ b/client/utils/errorCodeMap.ts
@@ -1,5 +1,7 @@
 type ProblemDetailProperties = {
   code?: number
+  requestId?: string
+  userId?: string
 }
 
 export type DiagnosticContext = {
@@ -71,9 +73,15 @@ export function extractErrorCode(payload: unknown): number | undefined {
 export function extractDiagnosticContext(payload: unknown): DiagnosticContext {
   if (!payload || typeof payload !== 'object') return {}
   const pd = payload as ApiProblemDetail
+  const requestId = typeof pd.requestId === 'string'
+    ? pd.requestId
+    : typeof pd.properties?.requestId === 'string' ? pd.properties.requestId : undefined
+  const userId = typeof pd.userId === 'string'
+    ? pd.userId
+    : typeof pd.properties?.userId === 'string' ? pd.properties.userId : undefined
   return {
-    requestId: typeof pd.requestId === 'string' ? pd.requestId : undefined,
-    userId: typeof pd.userId === 'string' ? pd.userId : undefined,
+    requestId,
+    userId,
     code: extractErrorCode(payload),
   }
 }

--- a/client/utils/errorCodeMap.ts
+++ b/client/utils/errorCodeMap.ts
@@ -2,9 +2,17 @@ type ProblemDetailProperties = {
   code?: number
 }
 
+export type DiagnosticContext = {
+  requestId?: string
+  userId?: string
+  code?: number
+}
+
 export type ApiProblemDetail = {
   code?: number
   properties?: ProblemDetailProperties
+  requestId?: string
+  userId?: string
 }
 
 type ErrorMessage = {
@@ -58,6 +66,25 @@ export function extractErrorCode(payload: unknown): number | undefined {
   if (typeof problemDetail.properties?.code === 'number') return problemDetail.properties.code
 
   return undefined
+}
+
+export function extractDiagnosticContext(payload: unknown): DiagnosticContext {
+  if (!payload || typeof payload !== 'object') return {}
+  const pd = payload as ApiProblemDetail
+  return {
+    requestId: typeof pd.requestId === 'string' ? pd.requestId : undefined,
+    userId: typeof pd.userId === 'string' ? pd.userId : undefined,
+    code: extractErrorCode(payload),
+  }
+}
+
+export function buildDiagnosticText(ctx: DiagnosticContext): string {
+  return [
+    ctx.requestId ? `requestId: ${ctx.requestId}` : null,
+    ctx.userId ? `userId: ${ctx.userId}` : null,
+    ctx.code !== undefined ? `code: ${ctx.code}` : null,
+    `date: ${new Date().toISOString()}`,
+  ].filter(Boolean).join('\n')
 }
 
 export function getErrorMessageByCode(code?: number): ErrorMessage {

--- a/docs/features/error-diagnostic-copy/application_error-diagnostic-copy.md
+++ b/docs/features/error-diagnostic-copy/application_error-diagnostic-copy.md
@@ -1,0 +1,65 @@
+# Application Module — Error Diagnostic Context in API Error Responses
+
+**Context**
+When an error occurs, users need to report it to support. Currently, error responses contain only a
+numeric code and a message, providing no stable identifier that support can use to locate the
+incident in logs or the database.
+
+The project already has an MDC infrastructure (`MdcContextProvider`, `MdcKeys`, `LoggingCommandBus`,
+`LoggingQueryBus`) that injects domain context keys (`bookletId`, `transactionId`) into the SLF4J
+MDC during bus dispatch. However, those keys are **removed in the `finally` block** before the
+exception propagates to `ProblemDetailHandler` — so they are not available at error-handling time.
+
+The right strategy is to generate a `requestId` UUID at the HTTP boundary (servlet filter), store it
+in MDC for the **full request lifetime** (including in exception handlers), and expose it in every
+error response. Support can then grep logs by `requestId` and find all lines for that request —
+including the ones where `bookletId` and `transactionId` were still in MDC during dispatch.
+
+**Scope (application)**
+- Add `REQUEST_ID` to `MdcKeys` in the domain (`domain/port/input/MdcContext.kt`).
+- Create a servlet filter (e.g. `RequestIdFilter`) that generates a UUID v4 per request, stores it
+  via `MDC.put(MdcKeys.REQUEST_ID, ...)`, and removes it in a `finally` block after the response
+  is committed. This filter must run before Spring Security so the key is present even for 401/403
+  responses.
+- Update `ProblemDetailHandler.buildResponse()` to read `MDC.get(MdcKeys.REQUEST_ID)` and attach it
+  as a custom property `"requestId"` on the `ProblemDetail` when non-null.
+- Extract the authenticated `userId` from the Spring Security context and attach it as `"userId"` on
+  the `ProblemDetail` when a principal is present.
+- No domain use-case or infrastructure persistence changes are required.
+
+**Acceptance Criteria**
+Feature: Error diagnostic context in API error responses
+  In order to locate the failing request quickly in logs and the database
+  As a support engineer
+  I want every error response to carry a stable requestId and the affected userId
+
+Scenario: Authenticated request fails — both fields are present
+  Given a servlet filter that set requestId in MDC before the request reached the controller
+  And an authenticated user whose request triggers a domain failure
+  When ProblemDetailHandler returns a 4xx or 5xx ProblemDetail
+  Then the response JSON includes a non-null "requestId" UUID field
+  And the response JSON includes a "userId" field matching the authenticated user's ID
+  And the server log line from logException includes the requestId in the MDC output
+
+Scenario: Unauthenticated request fails — requestId only
+  Given a request without a valid authentication token that triggers a 401 response
+  When ProblemDetailHandler returns the ProblemDetail
+  Then the response JSON includes a non-null "requestId" UUID field
+  And the response JSON does NOT include a "userId" field
+
+Scenario: Every failing request gets a distinct requestId
+  Given two concurrent requests that both fail
+  When both ProblemDetail responses are returned
+  Then each response carries a different "requestId" value
+
+Scenario: Successful requests do not expose requestId
+  Given an authenticated user whose request succeeds
+  When the API returns a 2xx response
+  Then the response body does not contain a "requestId" field
+
+Scenario: requestId links error response to domain context in logs
+  Given a command that implements MdcContextProvider exposing bookletId and transactionId
+  And the command fails with a domain error
+  When the ProblemDetail is returned with its requestId
+  Then the server logs contain lines with requestId, bookletId, and transactionId
+  So that support can grep by requestId to retrieve the full domain context

--- a/docs/features/error-diagnostic-copy/client_error-diagnostic-copy.md
+++ b/docs/features/error-diagnostic-copy/client_error-diagnostic-copy.md
@@ -1,0 +1,54 @@
+# Client Module — Copy Diagnostic Context to Clipboard on Error
+
+**Context**
+When an error occurs, users need to send diagnostic information to support (via email or a report form).
+Once the backend exposes a `requestId` and `userId` in every error response, the frontend must surface
+these values in a way that the user can copy with a single click, ready to paste into a support message.
+
+The copy action must be frictionless: one button, immediate feedback, no manual selection required.
+
+**Scope (client)**
+- Extend `ApiProblemDetail` type (`utils/errorCodeMap.ts`) with optional `requestId: string` and
+  `userId: string` fields.
+- Update `useJToast.errorAxios()` (or a shared helper) to detect the presence of `requestId` in the
+  error response and, when present, append a **"Copier les infos de débogage"** action to the toast.
+- Clicking that action copies a formatted diagnostic block to the clipboard:
+  ```
+  requestId: <value>
+  userId: <value>       ← omitted when absent
+  code: <value>
+  date: <ISO timestamp>
+  ```
+- After a successful copy, replace the button label with **"Copié !"** for 2 seconds, then restore it.
+- Errors without a `requestId` (e.g. network-only failures before the server responds) show the
+  existing toast behaviour unchanged — no regression.
+- No backend, domain, or infrastructure changes are part of this issue.
+
+**Acceptance Criteria**
+Feature: Copy diagnostic context to clipboard on error
+  In order to include precise information in my support report
+  As a user who encounters an error
+  I want to copy the diagnostic context to my clipboard with one click
+
+Scenario: Error response includes requestId — diagnostic button appears
+  Given an authenticated user whose action triggers an API error
+  And the error response includes a "requestId" field
+  When the error toast appears
+  Then a "Copier les infos de débogage" button is visible inside the toast
+
+Scenario: Clicking the button copies the diagnostic block
+  Given an error toast with a "Copier les infos de débogage" button
+  When the user clicks the button
+  Then the clipboard contains requestId, userId (if present), error code, and an ISO timestamp
+  And the button label changes to "Copié !" for approximately 2 seconds then reverts
+
+Scenario: Error response without requestId — no diagnostic button
+  Given a network error or a legacy error response without "requestId"
+  When the error toast appears
+  Then no "Copier les infos de débogage" button is shown
+  And the toast behaves exactly as before
+
+Scenario: userId is omitted from the copied block when absent
+  Given an unauthenticated request that returns a 401 error with requestId but no userId
+  When the user copies the diagnostic block
+  Then the clipboard text includes "requestId" but does NOT include a "userId" line

--- a/docs/technical/observability/2026-06-01-request-id-diagnostic-context.md
+++ b/docs/technical/observability/2026-06-01-request-id-diagnostic-context.md
@@ -1,0 +1,132 @@
+# Request-ID Diagnostic Context in Error Responses
+
+> **Topic**: Observability — per-request correlation ID in API error responses
+> **Date**: 2026-06-01
+> **Author**: Technical Backend
+
+---
+
+## Context
+When an API error occurs, users must be able to copy a stable identifier and send it to support so
+the failing request can be located in logs and correlated to database state. Currently, error
+responses expose only a numeric `code` and a message — there is no request-scoped identifier.
+
+## Current State
+
+### MDC infrastructure (domain + application)
+- `MdcContextProvider` / `MdcKeys` (`BOOKLET_ID`, `TRANSACTION_ID`) — domain, no Spring dependency.
+- `LoggingCommandBus` / `LoggingQueryBus` — inject those keys into SLF4J MDC for the duration of
+  the bus dispatch, then **remove them in the `finally` block** before the result (or exception)
+  returns to the controller.
+- Consequence: by the time an exception reaches `ProblemDetailHandler`, the domain MDC keys have
+  already been cleared. They **cannot** be forwarded to the error response from the handler.
+
+### Spring Security filter chain
+`SecurityConfig` registers `JwtCookieAuthenticationFilter` before
+`UsernamePasswordAuthenticationFilter`. There is no existing request-scoped ID filter.
+
+### Error response shape
+`ProblemDetailHandler.buildResponse()` produces a Spring `ProblemDetail` with `code` and `errorKey`
+custom properties. No `requestId` or `userId` today.
+
+### User identity
+`JmanagerUserAuthDetail` (carrying `id: UUID`) is stored as the principal in
+`SecurityContextHolder`. A safe null-capable read is needed in the handler to avoid throwing
+`UnauthorizedRequestException` for unauthenticated error paths.
+
+## Analysis
+
+### Why a servlet-level filter, not a Security chain filter
+Adding `requestId` injection inside the Spring Security filter chain (via `addFilterBefore` in
+`SecurityConfig`) would work for API requests, but the filter would only be active within the
+security chain. Registering the filter as a `@Component` with `@Order(Ordered.HIGHEST_PRECEDENCE)`
+at the servlet container level means it runs **before** the `DelegatingFilterProxy` and therefore
+before Spring Security itself. This guarantees `requestId` is in the MDC for every request:
+authentication failures, CORS pre-flights, and Spring Security's own exceptions.
+
+### Why the `finally` block in the bus does NOT need to change
+The bus removes domain MDC keys (`bookletId`, `transactionId`) after dispatch — that is correct
+behaviour (prevents context leaks across dispatches). The `requestId` is set independently at the
+HTTP boundary, outside the bus lifecycle, so it survives the bus `finally` block and is still
+present in the MDC when `ProblemDetailHandler` runs.
+
+Support flow: grep logs by `requestId` → find all log lines for that request, including those
+emitted during the bus dispatch **before** the `finally` removed `bookletId`/`transactionId`.
+
+### Security consideration
+Exposing `userId` in error responses is acceptable for this application (authenticated users
+reporting their own errors). It must be omitted for unauthenticated paths (401/403 on public
+endpoints) to avoid leaking internal identifiers to anonymous callers.
+
+## Recommended Approach
+
+### Step 1 — `MdcKeys.REQUEST_ID` constant (domain)
+Add `REQUEST_ID = "requestId"` to the existing `MdcKeys` object in
+`domain/src/main/kotlin/fr/sacane/jmanager/domain/port/input/MdcContext.kt`.
+No Spring dependency — the domain only holds the string constant.
+
+### Step 2 — `RequestIdFilter` (application)
+
+```kotlin
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+class RequestIdFilter : OncePerRequestFilter() {
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        chain: FilterChain,
+    ) {
+        MDC.put(MdcKeys.REQUEST_ID, UUID.randomUUID().toString())
+        try {
+            chain.doFilter(request, response)
+        } finally {
+            MDC.remove(MdcKeys.REQUEST_ID)
+        }
+    }
+}
+```
+
+`@Order(Ordered.HIGHEST_PRECEDENCE)` places it as the first servlet filter, before Spring Security.
+No `FilterRegistrationBean` needed — Spring Boot auto-registers `@Component` servlet filters.
+
+### Step 3 — `ProblemDetailHandler.buildResponse()` (application)
+
+Add two property injections at the end of `buildResponse()`:
+
+```kotlin
+MDC.get(MdcKeys.REQUEST_ID)?.let { problemDetail.setProperty("requestId", it) }
+currentUserIdOrNull()?.let { problemDetail.setProperty("userId", it.toString()) }
+```
+
+Add a private safe-read helper (no exception for unauthenticated paths):
+
+```kotlin
+private fun currentUserIdOrNull(): UUID? =
+    (SecurityContextHolder.getContext().authentication?.principal as? JmanagerUserAuthDetail)?.id
+```
+
+## Implementation Notes
+
+| File | Change |
+|---|---|
+| `domain/.../MdcContext.kt` | Add `REQUEST_ID = "requestId"` to `MdcKeys` |
+| `application/.../api/RequestIdFilter.kt` | New file — `OncePerRequestFilter` with `@Component @Order(HIGHEST_PRECEDENCE)` |
+| `application/.../api/ProblemDetailHandler.kt` | `buildResponse()` reads MDC + SecurityContext; add `currentUserIdOrNull()` helper |
+
+No new Gradle dependency required. All needed types (`OncePerRequestFilter`, `MDC`,
+`SecurityContextHolder`, `Ordered`) are already on the classpath via `spring-boot-starter-web` and
+`spring-boot-starter-security`.
+
+## Trade-offs & Risks
+
+| Concern | Impact | Mitigation |
+|---|---|---|
+| MDC leak between requests in thread-pool | High | `finally` in `RequestIdFilter` removes the key unconditionally — safe |
+| `userId` exposed in 4xx responses | Low | `currentUserIdOrNull()` returns `null` for unauthenticated paths — omitted |
+| `requestId` absent if filter not reached (e.g. container-level 400) | Low | `MDC.get()` returns `null` → `setProperty` skipped, no NPE |
+| Filter order conflicts with future filters | Low | `HIGHEST_PRECEDENCE` is idiomatic for cross-cutting servlet filters |
+
+## References
+- [SLF4J MDC documentation](https://logback.qos.ch/manual/mdc.html)
+- [Spring `OncePerRequestFilter` Javadoc](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/filter/OncePerRequestFilter.html)
+- [Spring Boot filter ordering](https://docs.spring.io/spring-boot/docs/current/reference/html/web.html#web.servlet.embedded-container.customizing.samesite)

--- a/domain/src/main/kotlin/fr/sacane/jmanager/domain/port/input/MdcContext.kt
+++ b/domain/src/main/kotlin/fr/sacane/jmanager/domain/port/input/MdcContext.kt
@@ -23,4 +23,5 @@ interface MdcContextProvider {
 object MdcKeys {
     const val BOOKLET_ID = "bookletId"
     const val TRANSACTION_ID = "transactionId"
+    const val REQUEST_ID = "requestId"
 }


### PR DESCRIPTION
## Summary

- Add a `RequestIdFilter` (`@Order(HIGHEST_PRECEDENCE)`) that generates a UUID per HTTP request and stores it in the SLF4J MDC under `requestId`. MDC is cleared in a `finally` block at the end of each request.
- Add `LoggingCommandBus` / `LoggingQueryBus` decorators that inject domain context (`bookletId`, `transactionId`, etc.) into the MDC before each dispatch when the command/query implements `MdcContextProvider`. Keys persist until the filter's `MDC.clear()`, so they are available in error handlers.
- Add `MdcContextProvider` port and `MdcKeys` constants in the domain; implemented on `FindBookletByIdQuery`, `DeleteBookletByIdCommand`, and a dozen other commands/queries with identifiable context.
- Update `ProblemDetailHandler.buildResponse` to copy the full MDC map into `ProblemDetail.properties` and add `userId` from `SecurityContextHolder` when the user is authenticated — every exception handler (404, 403, 400, 401, 500…) now exposes `properties.requestId`, `properties.userId`, and domain context.
- Add `ProblemDetailAuthenticationEntryPoint` to replace `HttpStatusEntryPoint` in `SecurityConfig` — Spring Security 401 rejections now return an `application/problem+json` body with `properties.requestId` instead of an empty response.
- Enrich the Logback JSON pattern with `%X{requestId}`, `%X{bookletId}`, `%X{transactionId}` so logs and error responses can be correlated on the support side.

## Test plan

- [x] `ProblemDetailHandlerTest` — unit tests for all exception handlers: MDC entries appear in `properties`, `userId` present when authenticated, absent when not
- [x] `DiagnosticContextIntegrationTest` — full chain `RequestIdFilter → Spring Security → Bus (MDC) → Controller → ProblemDetailHandler → JSON`: `properties.requestId` always present, `properties.bookletId` matches path variable, `properties.userId` matches authenticated user or absent, two requests produce different `requestId` values
- [x] `BookletControllerTest` — 400/404 error responses carry `properties.requestId` and `properties.userId`
- [x] `SessionControllerTest` — login 404/403/400, settings 400/403, unauthenticated consent 401 all carry `properties.requestId`; unauthenticated responses carry no `properties.userId`
- [x] Full suite green: `./gradlew test` — 284 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)