### PR TITLE
fix(csv): allow numeric labels on import

### DIFF
--- a/docs/bugs/numeric-label-csv-import/REPORT.md
+++ b/docs/bugs/numeric-label-csv-import/REPORT.md
@@ -1,0 +1,21 @@
+# Bug Report — CSV import blocked when label is numeric
+
+**Date**: 2026-06-02
+
+## Symptom
+Importing a CSV file where a transaction label is a purely numeric string (e.g. `"123"`, `"4501"`) was rejected with a `POSSIBLE_COLUMN_SWAP` error, preventing any import. The system incorrectly assumed the numeric label was a misplaced amount.
+
+## Root Cause
+`validateLabelColumn` in [`CsvFileValidator.kt`](../../../domain/src/main/kotlin/fr/sacane/jmanager/domain/usecase/csv/CsvFileValidator.kt) called `CsvValidationUtils.looksLikeAmount()` on the label value and returned a **blocking error** (`CsvValidationIssue`) when the check returned `true`. Because `looksLikeAmount` parses any string that is a valid `BigDecimal`, any integer or decimal label failed validation with `POSSIBLE_COLUMN_SWAP`, stopping the import.
+
+## Fix
+Extracted the numeric-label heuristic out of `validateLabelColumn` into a new private method `checkLabelAmountPattern`. This method returns a `CsvValidationIssue` that is now added to **warnings** (not errors) in `validateDataLine`. A numeric label still produces a `POSSIBLE_COLUMN_SWAP` warning to inform the user, but no longer blocks the import.
+
+Changed files:
+- [`domain/src/main/kotlin/…/usecase/csv/CsvFileValidator.kt`](../../../domain/src/main/kotlin/fr/sacane/jmanager/domain/usecase/csv/CsvFileValidator.kt)
+
+## Non-Regression Tests
+- `should accept a numeric label without blocking the import` — new test covering integer and decimal-looking labels
+- `should warn but not block when label column contains a numeric value` — updated existing test to reflect warning (not error) behaviour
+
+Location: [`domain/src/test/kotlin/…/usecase/csv/CsvFileValidatorTest.kt`](../../../domain/src/test/kotlin/fr/sacane/jmanager/domain/usecase/csv/CsvFileValidatorTest.kt)

--- a/domain/src/main/kotlin/fr/sacane/jmanager/domain/usecase/csv/CsvFileValidator.kt
+++ b/domain/src/main/kotlin/fr/sacane/jmanager/domain/usecase/csv/CsvFileValidator.kt
@@ -176,6 +176,9 @@ class CsvFileValidator {
         val labelError = validateLabelColumn(row[LABEL_COLUMN], lineNumber)
         if (labelError != null) return LineValidationResult(error = labelError)
 
+        val labelWarning = checkLabelAmountPattern(row[LABEL_COLUMN], lineNumber)
+        labelWarning?.let { warnings.add(it) }
+
         val amountResult = validateAmountColumns(row[DEPENSE_COLUMN], row[RECETTE_COLUMN], lineNumber, expectedDecimalSeparator, csvSeparator)
         if (amountResult.error != null) return LineValidationResult(error = amountResult.error)
         amountResult.warnings?.let { warnings.addAll(it) }
@@ -245,14 +248,6 @@ class CsvFileValidator {
             )
         }
 
-        if (CsvValidationUtils.looksLikeAmount(labelStr)) {
-            return CsvValidationIssue(
-                lineNumber = lineNumber,
-                type = CsvReportType.POSSIBLE_COLUMN_SWAP,
-                message = "Line $lineNumber: Label looks like a numeric value ($labelStr). Check if columns are swapped"
-            )
-        }
-
         if (labelStr.trim().length > 200) {
             return CsvValidationIssue(
                 lineNumber = lineNumber,
@@ -262,6 +257,15 @@ class CsvFileValidator {
         }
 
         return null
+    }
+
+    private fun checkLabelAmountPattern(labelStr: String, lineNumber: Int): CsvValidationIssue? {
+        if (!CsvValidationUtils.looksLikeAmount(labelStr)) return null
+        return CsvValidationIssue(
+            lineNumber = lineNumber,
+            type = CsvReportType.POSSIBLE_COLUMN_SWAP,
+            message = "Line $lineNumber: Label looks like a numeric value ($labelStr). Check if columns are swapped"
+        )
     }
 
     private data class AmountValidationResult(

--- a/domain/src/test/kotlin/fr/sacane/jmanager/domain/usecase/csv/CsvFileValidatorTest.kt
+++ b/domain/src/test/kotlin/fr/sacane/jmanager/domain/usecase/csv/CsvFileValidatorTest.kt
@@ -343,7 +343,7 @@ class CsvFileValidatorTest {
     }
 
     @Test
-    fun `should return error for column swap detection - label column contains number`() {
+    fun `should warn but not block when label column contains a numeric value`() {
         val rows = listOf(
             arrayOf("date", "label", "depense", "recette", "tag"),
             arrayOf("15-01-2025", "45.50", "Groceries", "", "")
@@ -353,9 +353,30 @@ class CsvFileValidatorTest {
 
         result.assertSuccess()
         result.onSuccess { report ->
+            // "Groceries" as amount is still an invalid format error
             assertTrue(report.hasErrors)
-            assertEquals(1, report.errors.size)
-            assertEquals(CsvReportType.POSSIBLE_COLUMN_SWAP, report.errors[0].type)
+            assertEquals(CsvReportType.INVALID_AMOUNT_FORMAT, report.errors[0].type)
+            // The numeric label itself must not generate a POSSIBLE_COLUMN_SWAP error
+            assertTrue(report.errors.none { it.type == CsvReportType.POSSIBLE_COLUMN_SWAP })
+        }
+    }
+
+    @Test
+    @DisplayName("Should accept a purely numeric label without error")
+    fun `should accept a numeric label without blocking the import`() {
+        val rows = listOf(
+            arrayOf("date", "label", "depense", "recette", "tag"),
+            arrayOf("15-01-2025", "123", "45.50", "", ""),
+            arrayOf("16-01-2025", "4501", "", "2500.00", "")
+        )
+
+        val result = validator.validate(rows, availableTags)
+
+        result.assertSuccess()
+        result.onSuccess { report ->
+            assertFalse(report.hasErrors, "A numeric label should not block import. Errors: ${report.errors.joinToString { it.message }}")
+            assertTrue(report.canImport)
+            assertEquals(2, report.validLines)
         }
     }
 


### PR DESCRIPTION
## Summary

- Un label purement numérique (ex. `123`, `4501`) était rejeté avec une erreur `POSSIBLE_COLUMN_SWAP` lors de l'import CSV, bloquant l'import
- `validateLabelColumn` traitait le check `looksLikeAmount()` comme une erreur bloquante au lieu d'un simple avertissement
- Extraction de la heuristique dans `checkLabelAmountPattern` et démotion en warning : le label numérique est accepté, l'indice de swap reste visible

## Test plan

- [ ] Importer un CSV avec un label numérique entier (ex. `123`) → import accepté
- [ ] Importer un CSV avec un label numérique décimal (ex. `45.50`) → import accepté (warning possible)
- [ ] Importer un CSV avec colonnes réellement inversées (montant en date) → erreur `POSSIBLE_COLUMN_SWAP` toujours levée sur la colonne date
- [ ] `./gradlew :domain:test :application:test` → tous verts

🤖 Generated with [Claude Code](https://claude.com/claude-code)