### PR TITLE
chore(rgpd): legal links in sidebar, Resend DPA in privacy policy, fix version display

### DIFF
--- a/application/build.gradle.kts
+++ b/application/build.gradle.kts
@@ -81,4 +81,10 @@ tasks {
     processResources {
         mustRunAfter(":client:bundle")
     }
+    // Ensure build-info.properties is generated before the app starts locally.
+    // springBoot { buildInfo() } only wires bootBuildInfo into jar/bootJar by
+    // default — bootRun must declare the dependency explicitly.
+    named("bootRun") {
+        dependsOn("bootBuildInfo")
+    }
 }

--- a/client/components/app-sidebar.vue
+++ b/client/components/app-sidebar.vue
@@ -163,6 +163,15 @@ onUnmounted(() => {
         <div class="sidebar-footer">
           <Profile />
           <span v-if="version" class="app-version">{{ `v${version}` }}</span>
+          <div class="legal-links">
+            <NuxtLink to="/privacy" class="legal-link" @click="closeOnNavigateIfMobile()">
+              Confidentialité
+            </NuxtLink>
+            <span class="legal-sep" aria-hidden="true">·</span>
+            <NuxtLink to="/terms" class="legal-link" @click="closeOnNavigateIfMobile()">
+              CGU
+            </NuxtLink>
+          </div>
         </div>
       </div>
     </aside>
@@ -590,6 +599,31 @@ onUnmounted(() => {
   font-family: monospace;
   color: rgba(255, 255, 255, 0.3);
   letter-spacing: 0.03em;
+  user-select: none;
+}
+
+.legal-links {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  margin-top: 0.5rem;
+}
+
+.legal-link {
+  font-size: 0.7rem;
+  color: rgba(255, 255, 255, 0.3);
+  text-decoration: none;
+  transition: color 0.2s ease;
+
+  &:hover {
+    color: rgba(255, 255, 255, 0.6);
+    text-decoration: underline;
+  }
+}
+
+.legal-sep {
+  font-size: 0.7rem;
+  color: rgba(255, 255, 255, 0.2);
   user-select: none;
 }
 

--- a/client/composables/useAppVersion.ts
+++ b/client/composables/useAppVersion.ts
@@ -3,11 +3,27 @@ import axios from 'axios'
 export default function useAppVersion() {
   const version = useState<string | null>('app:version', () => null)
 
+  /**
+   * Derives the actuator base URL from the configured apiUrl.
+   * When apiUrl is relative (production, e.g. "/api/"), the actuator lives
+   * on the same origin as the page — use window.location.origin.
+   * When apiUrl is absolute (local dev, e.g. "http://localhost:8080/api/"),
+   * extract the origin from it.
+   */
+  function resolveActuatorBase(apiUrl: string): string {
+    try {
+      return new URL(apiUrl).origin
+    } catch {
+      // Relative URL — production mode: same origin as the SPA
+      return window.location.origin
+    }
+  }
+
   async function fetchVersion(): Promise<void> {
     try {
       const config = useRuntimeConfig()
-      const origin = new URL(config.public.apiUrl).origin
-      const response = await axios.get(`${origin}/actuator/info`)
+      const base = resolveActuatorBase(config.public.apiUrl as string)
+      const response = await axios.get(`${base}/actuator/info`)
       version.value = response.data?.build?.version ?? null
     } catch {
       version.value = null

--- a/client/pages/privacy.vue
+++ b/client/pages/privacy.vue
@@ -15,7 +15,7 @@ definePageMeta({ layout: 'legal' })
         Politique de Confidentialité
       </h1>
       <p class="body-sm">
-        Version 1.0 &mdash; En vigueur à compter du 28 mai 2026
+        Version 1.1 &mdash; En vigueur à compter du 4 juin 2026
       </p>
     </header>
 
@@ -187,8 +187,14 @@ definePageMeta({ layout: 'legal' })
       <ul class="list body-base flex flex-col gap-1 pl-5">
         <li>L'équipe technique de JManager dans le cadre de la maintenance et du support.</li>
         <li>
-          Le prestataire d'hébergement <strong>Pulseheberge</strong>, lié par des clauses contractuelles
+          Le prestataire d'hébergement <strong>PulseHeberg</strong>, lié par des clauses contractuelles
           conformes au RGPD.
+        </li>
+        <li>
+          Le prestataire d'envoi d'e-mails <strong>Resend</strong> (Resend Inc., États-Unis), qui reçoit
+          uniquement les adresses e-mail nécessaires à l'acheminement des messages transactionnels
+          (ex. : e-mail de bienvenue). Un accord de traitement des données (DPA) incluant les
+          Clauses Contractuelles Types (CCT) de la Commission européenne est en place.
         </li>
       </ul>
     </section>
@@ -199,8 +205,14 @@ definePageMeta({ layout: 'legal' })
         5. Transferts hors Union européenne
       </h2>
       <p class="body-base">
-        Les données sont hébergées sur des serveurs situés dans l'Union européenne.
-        Aucun transfert vers des pays tiers n'est effectué.
+        Les données sont hébergées sur des serveurs situés dans l'Union européenne (hébergeur : PulseHeberg).
+      </p>
+      <p class="body-base">
+        L'envoi des e-mails transactionnels implique la transmission de l'adresse e-mail du destinataire
+        à <strong>Resend Inc.</strong> (États-Unis). Ce transfert est encadré par les
+        <strong>Clauses Contractuelles Types (CCT)</strong> approuvées par la Commission européenne
+        (Art. 46 RGPD), incluses dans le DPA signé avec Resend. Les données traitées par Resend
+        sont hébergées sur des serveurs AWS situés dans l'Union européenne (région eu-west-1, Irlande).
       </p>
     </section>
 

--- a/client/tests/pages/privacy.spec.ts
+++ b/client/tests/pages/privacy.spec.ts
@@ -39,6 +39,12 @@ describe('pages/privacy', () => {
     expect(wrapper.text()).toContain('CNIL')
   })
 
+  it('mentions Resend as an email sub-processor', () => {
+    const wrapper = mountPage()
+    expect(wrapper.text()).toContain('Resend')
+    expect(wrapper.text()).toContain('Clauses Contractuelles Types')
+  })
+
   it('uses the legal layout', () => {
     // definePageMeta is stubbed — just verify the page mounts without errors
     expect(mountPage().exists()).toBe(true)


### PR DESCRIPTION
## Summary

- **Politique de confidentialité (v1.1)** — Ajout de Resend Inc. comme sous-traitant email (section 4) et mise à jour de la section transferts hors UE (section 5) avec mention des CCT et de la région AWS eu-west-1. Nécessaire pour la conformité RGPD après l'intégration de Resend pour les emails transactionnels.
- **Liens légaux dans le sidebar** — Ajout de `Confidentialité · CGU` dans le footer du sidebar pour que les utilisateurs connectés puissent accéder aux pages légales à tout moment (obligation RGPD Art. 13). Les liens ferment le sidebar sur mobile.
- **Fix version applicative** — Deux bugs corrigés qui empêchaient l'affichage de la version :
  - *Production* : `new URL("/api/")` levait une `TypeError` (URL relative) → fallback sur `window.location.origin`
  - *Dev local* : `bootRun` ne dépendait pas de `bootBuildInfo` → `/actuator/info` retournait `{}` → `dependsOn("bootBuildInfo")` ajouté

## Test plan

- [ ] Vérifier que `/privacy` mentionne Resend et les CCT
- [ ] Vérifier que les liens `Confidentialité` et `CGU` apparaissent en bas du sidebar une fois connecté
- [ ] Vérifier que la version s'affiche après `./gradlew bootRun` (dev local)
- [ ] Vérifier que la version s'affiche en production (JAR déployé)
- [ ] `pnpm test` — 372 tests passent ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)