### PR TITLE
feat(mobile): redesign booklet page responsive layout

### DIFF
--- a/client/components/booklet/BookletFilterActionBar.vue
+++ b/client/components/booklet/BookletFilterActionBar.vue
@@ -53,45 +53,46 @@ const emit = defineEmits<{
 <template>
   <!-- Filtres + Actions -->
   <div v-if="isMobile || !hideActionButtons" class="flex items-center gap-2 mb-2 overflow-x-auto">
-    <!-- Mobile: compact filter chips -->
+    <!-- Mobile: filter chips -->
     <template v-if="isMobile">
+      <!-- Local filters -->
       <button
-        class="flex items-center gap-1 px-2 py-0.5 rounded-md text-xs font-bold transition-all whitespace-nowrap shrink-0 border"
+        class="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-bold transition-all whitespace-nowrap shrink-0 border"
         :class="transactionFilter === 'all' && globalFilter === 'none'
           ? 'border-[var(--primary)] text-[var(--primary)] bg-[rgba(101,8,204,0.07)]'
           : 'border-[var(--card-border)] text-[var(--text-secondary)]'"
         @click="emit('update:transactionFilter', 'all')"
       >
-        <i class="pi pi-list text-[0.6rem]" />
+        <i class="pi pi-list text-xs" />
         <span>{{ transactionsCount }}</span>
       </button>
       <button
-        class="flex items-center gap-1 px-2 py-0.5 rounded-md text-xs font-bold transition-all whitespace-nowrap shrink-0 border"
+        class="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-bold transition-all whitespace-nowrap shrink-0 border"
         :class="transactionFilter === 'confirmed' && globalFilter === 'none'
           ? 'border-emerald-500 text-emerald-600 bg-emerald-500/8'
           : 'border-[var(--card-border)] text-[var(--text-secondary)]'"
         @click="emit('update:transactionFilter', 'confirmed')"
       >
-        <i class="pi pi-check-circle text-[0.6rem]" />
+        <i class="pi pi-check-circle text-xs" />
         <span>{{ transactionsCount - previewTransactionsCount }}</span>
       </button>
       <button
-        class="flex items-center gap-1 px-2 py-0.5 rounded-md text-xs font-bold transition-all whitespace-nowrap shrink-0 border"
+        class="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-bold transition-all whitespace-nowrap shrink-0 border"
         :class="transactionFilter === 'preview' && globalFilter === 'none'
           ? 'border-amber-500 text-amber-600 bg-amber-500/8'
           : 'border-[var(--card-border)] text-[var(--text-secondary)]'"
         @click="emit('update:transactionFilter', 'preview')"
       >
-        <i class="pi pi-clock text-[0.6rem]" />
+        <i class="pi pi-clock text-xs" />
         <span>{{ previewTransactionsCount }}</span>
       </button>
 
-      <!-- Global filter separator -->
-      <div class="w-px h-4 bg-[var(--border-color)] mx-0.5 shrink-0" />
+      <!-- Separator -->
+      <div class="w-px h-5 bg-[var(--border-color)] mx-0.5 shrink-0" />
 
-      <!-- Global: all month -->
+      <!-- Global filters -->
       <button
-        class="flex items-center gap-1 px-2 py-0.5 rounded-md text-xs font-bold transition-all whitespace-nowrap shrink-0 border"
+        class="w-9 h-9 flex items-center justify-center rounded-lg text-xs font-bold transition-all shrink-0 border"
         :class="globalFilter === 'all'
           ? 'border-[var(--primary)] text-[var(--primary)] bg-[rgba(101,8,204,0.07)]'
           : 'border-[var(--card-border)] text-[var(--text-secondary)]'"
@@ -99,12 +100,10 @@ const emit = defineEmits<{
         aria-label="Tout le mois"
         @click="emit('update:globalFilter', globalFilter === 'all' ? 'none' : 'all')"
       >
-        <i class="text-[0.6rem]" :class="isGlobalFilterLoading && globalFilter === 'all' ? 'pi pi-spin pi-spinner' : 'pi pi-globe'" />
+        <i :class="isGlobalFilterLoading && globalFilter === 'all' ? 'pi pi-spin pi-spinner' : 'pi pi-globe'" />
       </button>
-
-      <!-- Global: previews month -->
       <button
-        class="flex items-center gap-1 px-2 py-0.5 rounded-md text-xs font-bold transition-all whitespace-nowrap shrink-0 border"
+        class="w-9 h-9 flex items-center justify-center rounded-lg text-xs font-bold transition-all shrink-0 border"
         :class="globalFilter === 'preview'
           ? 'border-amber-500 text-amber-600 bg-amber-500/8'
           : 'border-[var(--card-border)] text-[var(--text-secondary)]'"
@@ -112,23 +111,23 @@ const emit = defineEmits<{
         aria-label="Prévisionnelles du mois"
         @click="emit('update:globalFilter', globalFilter === 'preview' ? 'none' : 'preview')"
       >
-        <i class="text-[0.6rem]" :class="isGlobalFilterLoading && globalFilter === 'preview' ? 'pi pi-spin pi-spinner' : 'pi pi-calendar'" />
+        <i :class="isGlobalFilterLoading && globalFilter === 'preview' ? 'pi pi-spin pi-spinner' : 'pi pi-calendar'" />
       </button>
 
-      <!-- Tag filters (when options available) -->
+      <!-- Tag filters -->
       <template v-if="props.tagFilterOptions && props.tagFilterOptions.length > 1">
-        <div class="w-px h-4 bg-[var(--border-color)] mx-0.5 shrink-0" />
+        <div class="w-px h-5 bg-[var(--border-color)] mx-0.5 shrink-0" />
         <Select
           :model-value="selectedTagFilter"
           :options="tagFilterOptions"
           option-label="label"
           option-value="value"
           size="small"
-          class="!w-[80px] shrink-0"
+          class="!w-[90px] shrink-0"
           @update:model-value="(val: string) => emit('update:selectedTagFilter', val)"
         >
           <template #value="{ value: val }">
-            <span class="text-[0.65rem] font-semibold truncate block" :class="val ? 'text-[var(--text-primary)]' : 'text-[var(--text-secondary)]'">
+            <span class="text-xs font-semibold truncate block" :class="val ? 'text-[var(--text-primary)]' : 'text-[var(--text-secondary)]'">
               {{ val ? (tagFilterOptions?.find(o => o.value === val)?.label ?? val) : 'Tag' }}
             </span>
           </template>
@@ -144,11 +143,11 @@ const emit = defineEmits<{
           option-label="label"
           option-value="value"
           size="small"
-          class="!w-[80px] shrink-0"
+          class="!w-[90px] shrink-0"
           @update:model-value="(val: string) => emit('update:selectedSubTagFilter', val)"
         >
           <template #value="{ value: val }">
-            <span class="text-[0.65rem] font-semibold truncate block" :class="val ? 'text-[var(--text-primary)]' : 'text-[var(--text-secondary)]'">
+            <span class="text-xs font-semibold truncate block" :class="val ? 'text-[var(--text-primary)]' : 'text-[var(--text-secondary)]'">
               {{ val ? (subTagFilterOptions?.find(o => o.value === val)?.label ?? val) : 'S-tag' }}
             </span>
           </template>

--- a/client/components/booklet/BookletPageHeader.vue
+++ b/client/components/booklet/BookletPageHeader.vue
@@ -23,63 +23,115 @@ const emit = defineEmits<{
 </script>
 
 <template>
-  <div class="bg-[var(--card-bg)] rounded-xl py-1 px-3 shadow border border-[var(--card-border)] overflow-hidden mb-2">
-    <div class="flex items-center justify-between gap-2 flex-wrap">
-      <!-- Left: back + title + counts -->
-      <div class="flex items-center gap-2 min-w-0">
+  <div class="bg-[var(--card-bg)] rounded-xl shadow border border-[var(--card-border)] overflow-hidden mb-2">
+    <!-- Mobile layout: single compact row -->
+    <template v-if="isMobile">
+      <div class="flex items-start gap-2 px-3 py-2.5">
+        <!-- Back button -->
         <Button
-          class="text-[#FF5A08] !w-7 !h-7 rounded-full grid place-items-center hover:bg-[#FF5A08]/10 shrink-0"
+          class="text-[#FF5A08] !w-8 !h-8 rounded-full grid place-items-center hover:bg-[#FF5A08]/10 shrink-0 mt-0.5"
           icon="pi pi-arrow-left"
           text
           rounded
           @click="emit('back')"
         />
-        <div class="flex items-baseline gap-2 min-w-0 flex-wrap">
-          <h1 class="text-base font-extrabold bg-gradient-to-br from-[var(--primary)] to-[var(--primary-2)] text-transparent bg-clip-text m-0 leading-tight truncate">
+
+        <!-- Title + inline balances -->
+        <div class="flex-1 min-w-0">
+          <h1 class="text-sm font-extrabold bg-gradient-to-br from-[var(--primary)] to-[var(--primary-2)] text-transparent bg-clip-text m-0 leading-tight truncate">
             {{ displayLabel }}
           </h1>
-          <span class="text-xs font-semibold text-[var(--text-secondary)] whitespace-nowrap">{{ transactionsCount }} trans.</span>
-          <span v-if="previewTransactionsCount > 0" class="text-[#FF5A08] text-xs font-semibold whitespace-nowrap">{{ previewTransactionsCount }} en attente</span>
-        </div>
-      </div>
-
-      <!-- Right: balances + filters -->
-      <div class="flex items-center gap-2 shrink-0 flex-wrap">
-        <!-- Balances -->
-        <div class="flex items-center gap-2 sm:gap-4 px-3 py-1.5 sm:(px-5 py-2.5) bg-gradient-to-br from-[var(--bg-tertiary)] to-[var(--bg-secondary)] rounded-xl border border-[var(--card-border)] shadow-sm">
-          <div class="flex flex-col items-center gap-0.5">
-            <span class="text-[0.6rem] font-semibold uppercase tracking-widest text-[var(--text-tertiary)]">Réel</span>
-            <span class="text-sm sm:text-xl font-extrabold tabular-nums text-[var(--primary)]">{{ realSold.toFixed(2) }} €</span>
-          </div>
-          <div class="w-px h-6 sm:h-10 bg-[var(--border-color)]" />
-          <div class="flex flex-col items-center gap-0.5">
-            <span class="text-[0.6rem] font-semibold uppercase tracking-widest text-[var(--text-tertiary)]">Prévis.</span>
-            <span class="text-sm sm:text-xl font-extrabold tabular-nums text-[#FF5A08]">{{ previewSold.toFixed(2) }} €</span>
+          <div class="flex items-center gap-2 mt-1">
+            <span class="text-sm font-extrabold tabular-nums text-[var(--primary)] whitespace-nowrap">{{ realSold.toFixed(2) }}&nbsp;€</span>
+            <span class="text-[var(--text-muted)] text-xs">·</span>
+            <span class="text-sm font-extrabold tabular-nums text-[#FF5A08] whitespace-nowrap">{{ previewSold.toFixed(2) }}&nbsp;€</span>
           </div>
         </div>
 
-        <!-- Month + Year -->
-        <Select
-          :model-value="selectedMonth"
-          :options="monthOptions"
-          placeholder="Mois"
-          class="!w-[90px] sm:!w-[120px] border-1 rounded-lg bg-transparent"
-          size="small"
-          @update:model-value="(val: string) => emit('update:selectedMonth', val)"
-          @change="emit('month-change')"
-        />
-        <DatePicker
-          :model-value="dateYear"
-          view="year"
-          date-format="yy"
-          class="!w-[70px] sm:!w-[90px] rounded-lg cursor-pointer bg-transparent"
-          placeholder="Année"
-          :show-icon="false"
-          @update:model-value="(val: Date) => emit('update:dateYear', val)"
-          @date-select="emit('year-change')"
-        />
+        <!-- Month + Year stacked, compact with abbreviated display -->
+        <div class="flex flex-col items-end gap-1 shrink-0">
+          <Select
+            :model-value="selectedMonth"
+            :options="monthOptions"
+            placeholder="Mois"
+            class="!w-[86px]"
+            size="small"
+            @update:model-value="(val: string) => emit('update:selectedMonth', val)"
+            @change="emit('month-change')"
+          >
+            <template #value="{ value: val }">
+              <span class="text-xs font-bold truncate">{{ val ? val.slice(0, 4) : 'Mois' }}</span>
+            </template>
+          </Select>
+          <DatePicker
+            :model-value="dateYear"
+            view="year"
+            date-format="yy"
+            class="!w-[86px] cursor-pointer"
+            placeholder="Année"
+            :show-icon="false"
+            @update:model-value="(val: Date) => emit('update:dateYear', val)"
+            @date-select="emit('year-change')"
+          />
+        </div>
       </div>
-    </div>
+    </template>
+
+    <!-- Desktop layout (unchanged) -->
+    <template v-else>
+      <div class="flex items-center justify-between gap-2 flex-wrap py-1 px-3">
+        <!-- Left: back + title + counts -->
+        <div class="flex items-center gap-2 min-w-0">
+          <Button
+            class="text-[#FF5A08] !w-7 !h-7 rounded-full grid place-items-center hover:bg-[#FF5A08]/10 shrink-0"
+            icon="pi pi-arrow-left"
+            text
+            rounded
+            @click="emit('back')"
+          />
+          <div class="flex items-baseline gap-2 min-w-0 flex-wrap">
+            <h1 class="text-base font-extrabold bg-gradient-to-br from-[var(--primary)] to-[var(--primary-2)] text-transparent bg-clip-text m-0 leading-tight truncate">
+              {{ displayLabel }}
+            </h1>
+            <span class="text-xs font-semibold text-[var(--text-secondary)] whitespace-nowrap">{{ transactionsCount }} trans.</span>
+            <span v-if="previewTransactionsCount > 0" class="text-[#FF5A08] text-xs font-semibold whitespace-nowrap">{{ previewTransactionsCount }} en attente</span>
+          </div>
+        </div>
+        <!-- Right: balances + filters -->
+        <div class="flex items-center gap-2 shrink-0 flex-wrap">
+          <div class="flex items-center gap-2 sm:gap-4 px-3 py-1.5 sm:(px-5 py-2.5) bg-gradient-to-br from-[var(--bg-tertiary)] to-[var(--bg-secondary)] rounded-xl border border-[var(--card-border)] shadow-sm">
+            <div class="flex flex-col items-center gap-0.5">
+              <span class="text-[0.6rem] font-semibold uppercase tracking-widest text-[var(--text-tertiary)]">Réel</span>
+              <span class="text-sm sm:text-xl font-extrabold tabular-nums text-[var(--primary)]">{{ realSold.toFixed(2) }} €</span>
+            </div>
+            <div class="w-px h-6 sm:h-10 bg-[var(--border-color)]" />
+            <div class="flex flex-col items-center gap-0.5">
+              <span class="text-[0.6rem] font-semibold uppercase tracking-widest text-[var(--text-tertiary)]">Prévis.</span>
+              <span class="text-sm sm:text-xl font-extrabold tabular-nums text-[#FF5A08]">{{ previewSold.toFixed(2) }} €</span>
+            </div>
+          </div>
+          <Select
+            :model-value="selectedMonth"
+            :options="monthOptions"
+            placeholder="Mois"
+            class="!w-[90px] sm:!w-[120px] border-1 rounded-lg bg-transparent"
+            size="small"
+            @update:model-value="(val: string) => emit('update:selectedMonth', val)"
+            @change="emit('month-change')"
+          />
+          <DatePicker
+            :model-value="dateYear"
+            view="year"
+            date-format="yy"
+            class="!w-[70px] sm:!w-[90px] rounded-lg cursor-pointer bg-transparent"
+            placeholder="Année"
+            :show-icon="false"
+            @update:model-value="(val: Date) => emit('update:dateYear', val)"
+            @date-select="emit('year-change')"
+          />
+        </div>
+      </div>
+    </template>
   </div>
 </template>
 
@@ -104,6 +156,13 @@ const emit = defineEmits<{
 :deep(.p-select-trigger),
 :deep(.p-icon) {
   color: var(--text-secondary) !important;
+}
+:deep(.p-select-label),
+:deep(.p-inputtext) {
+  padding: 0.25rem 0.4rem !important;
+}
+:deep(.p-select-trigger) {
+  width: 1.4rem !important;
 }
 :deep(.p-inputtext:focus),
 :deep(.p-inputtext:focus-visible),

--- a/client/components/booklet/BookletPageHeader.vue
+++ b/client/components/booklet/BookletPageHeader.vue
@@ -38,13 +38,19 @@ const emit = defineEmits<{
 
         <!-- Title + inline balances -->
         <div class="flex-1 min-w-0">
-          <h1 class="text-sm font-extrabold bg-gradient-to-br from-[var(--primary)] to-[var(--primary-2)] text-transparent bg-clip-text m-0 leading-tight truncate">
+          <h1 class="text-lg font-extrabold bg-gradient-to-br from-[var(--primary)] to-[var(--primary-2)] text-transparent bg-clip-text m-0 leading-tight truncate">
             {{ displayLabel }}
           </h1>
-          <div class="flex items-center gap-2 mt-1">
-            <span class="text-sm font-extrabold tabular-nums text-[var(--primary)] whitespace-nowrap">{{ realSold.toFixed(2) }}&nbsp;€</span>
-            <span class="text-[var(--text-muted)] text-xs">·</span>
-            <span class="text-sm font-extrabold tabular-nums text-[#FF5A08] whitespace-nowrap">{{ previewSold.toFixed(2) }}&nbsp;€</span>
+          <div class="flex items-center gap-3 mt-1.5">
+            <div class="flex flex-col gap-0">
+              <span class="text-[0.6rem] font-semibold uppercase tracking-widest text-[var(--text-tertiary)]">Réel</span>
+              <span class="text-base font-extrabold tabular-nums text-[var(--primary)] whitespace-nowrap leading-tight">{{ realSold.toFixed(2) }}&nbsp;€</span>
+            </div>
+            <span class="text-[var(--text-muted)] text-xs self-end mb-0.5">·</span>
+            <div class="flex flex-col gap-0">
+              <span class="text-[0.6rem] font-semibold uppercase tracking-widest text-[var(--text-tertiary)]">Prévis.</span>
+              <span class="text-base font-extrabold tabular-nums text-[#FF5A08] whitespace-nowrap leading-tight">{{ previewSold.toFixed(2) }}&nbsp;€</span>
+            </div>
           </div>
         </div>
 

--- a/client/pages/booklet/[id].vue
+++ b/client/pages/booklet/[id].vue
@@ -1111,7 +1111,7 @@ onUnmounted(() => {
                 v-for="(transaction, tIndex) in group.transactions"
                 :key="transaction.selectionKey || transaction.id || `t-${tIndex}`"
               >
-                <div v-if="tIndex > 0" class="h-px mx-3" style="background: rgba(255,255,255,0.25)" />
+                <div v-if="tIndex > 0" class="h-px mx-3 bg-black/10 dark:bg-white/20" />
               <div
                 class="flex items-center gap-3 py-3 px-3 transition-colors active:bg-[var(--card-hover-bg)]"
                 :class="isSelected(transaction) ? 'bg-[var(--primary)]/5' : transaction.isPreview ? 'bg-amber-500/5' : ''"

--- a/client/pages/booklet/[id].vue
+++ b/client/pages/booklet/[id].vue
@@ -1147,24 +1147,24 @@ onUnmounted(() => {
                   >
                     {{ transaction.isIncome ? '+' : '-' }}{{ Number.parseFloat(transaction?.value?.toString() ?? '0').toFixed(2) }}&nbsp;€
                   </span>
-                  <div class="flex items-center gap-1">
+                  <div class="flex items-center gap-1.5">
                     <button
                       v-if="transaction.id"
-                      class="w-8 h-8 flex items-center justify-center text-[#A30053] rounded-lg hover:bg-[#A30053]/10 transition-colors disabled:opacity-40"
+                      class="w-10 h-10 flex items-center justify-center rounded-xl bg-[#A30053]/10 border border-[#A30053]/20 text-[#A30053] hover:bg-[#A30053]/20 active:scale-95 transition-all disabled:opacity-40"
                       :disabled="isAnyActionLoading"
                       aria-label="Modifier"
                       @click.stop="onEditTransaction({ data: transaction })"
                     >
-                      <i class="pi pi-pencil text-xs" />
+                      <i class="pi pi-pencil text-sm" />
                     </button>
                     <button
                       v-if="transaction.isPreview"
-                      class="w-8 h-8 flex items-center justify-center text-emerald-600 rounded-lg hover:bg-emerald-600/10 transition-colors disabled:opacity-40"
+                      class="w-10 h-10 flex items-center justify-center rounded-xl bg-emerald-500/10 border border-emerald-500/25 text-emerald-400 hover:bg-emerald-500/20 active:scale-95 transition-all disabled:opacity-40"
                       :disabled="isAnyActionLoading"
                       aria-label="Valider"
                       @click.stop="onConfirmPreview(transaction)"
                     >
-                      <i class="pi pi-check text-xs" :class="isConfirmPreviewLoading ? 'pi-spin' : ''" />
+                      <i class="pi pi-check text-sm" :class="isConfirmPreviewLoading ? 'pi-spin' : ''" />
                     </button>
                   </div>
                 </div>

--- a/client/pages/booklet/[id].vue
+++ b/client/pages/booklet/[id].vue
@@ -645,6 +645,34 @@ function checkMobile() {
   isSidebarMode.value = !isMobile.value && (window.innerHeight < 768 || isSmallDesktop.value)
 }
 
+const FR_MONTHS = ['janvier', 'février', 'mars', 'avril', 'mai', 'juin', 'juillet', 'août', 'septembre', 'octobre', 'novembre', 'décembre']
+
+function toDateKey(d: Date): string {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+}
+
+function dayGroupLabel(dateKey: string): string {
+  const now = new Date()
+  const yesterday = new Date(now)
+  yesterday.setDate(now.getDate() - 1)
+  if (dateKey === toDateKey(now)) return "Aujourd'hui"
+  if (dateKey === toDateKey(yesterday)) return 'Hier'
+  const [, month, day] = dateKey.split('-').map(Number)
+  return `${day} ${FR_MONTHS[(month - 1)]}`
+}
+
+const transactionsByDay = computed(() => {
+  const map = new Map<string, DisplayTransaction[]>()
+  for (const t of filteredTransactions.value) {
+    const key = toDateKey(new Date(t.date))
+    if (!map.has(key)) map.set(key, [])
+    map.get(key)!.push(t)
+  }
+  return [...map.entries()]
+    .sort(([a], [b]) => b.localeCompare(a))
+    .map(([key, transactions]) => ({ dateKey: key, label: dayGroupLabel(key), transactions }))
+})
+
 const bookletTransactionColumns = computed<AppTableColumn[]>(() => [
   { selectionMode: 'multiple', style: { width: '3rem' } },
   { field: 'date', header: 'Date', sortable: true, style: { width: '90px', minWidth: '90px', maxWidth: '90px', textAlign: 'center' }, headerClass: 'col-header-center', slotName: 'date' },
@@ -1067,73 +1095,84 @@ onUnmounted(() => {
           <Button class="btn-primary" icon="pi pi-plus" label="Créer" @click="openCreationDialog" />
         </div>
 
-        <!-- Compact transaction rows -->
-        <div v-else class="bg-[var(--card-bg)] rounded-xl overflow-hidden border border-[var(--card-border)] shadow-sm">
-          <div
-            v-for="(transaction, tIndex) in filteredTransactions"
-            :key="transaction.selectionKey || transaction.id || `t-${tIndex}`"
-            class="flex items-start gap-2 py-1.5 px-3 border-b border-[var(--border-color)] last:border-b-0 transition-colors active:bg-[var(--card-hover-bg)]"
-            :class="isSelected(transaction)
-              ? 'bg-[var(--primary)]/5'
-              : transaction.isPreview ? 'bg-amber-500/5' : ''"
-            @click="toggleSelection(transaction)"
-          >
-            <!-- Checkbox -->
-            <Checkbox
-              :model-value="isSelected(transaction)"
-              :binary="true"
-              class="shrink-0 mt-1"
-              @click.stop="toggleSelection(transaction)"
-            />
-
-            <!-- Day -->
-            <span class="text-[0.65rem] font-bold text-[var(--text-tertiary)] w-5 text-center shrink-0 mt-1 tabular-nums leading-4">
-              {{ new Date(transaction.date).getDate() }}
-            </span>
-
-            <!-- Label + tag -->
-            <div class="flex-1 min-w-0 py-0.5">
-              <div class="flex items-center gap-1 leading-4">
-                <span class="text-xs font-semibold text-[var(--text-primary)] truncate">{{ transaction.label }}</span>
-                <i v-if="transaction.isPreview" class="pi pi-clock text-amber-500 text-[0.5rem] shrink-0" />
-              </div>
-              <span
-                class="inline-flex items-center mt-0.5 px-1.5 py-0 rounded text-[0.6rem] font-semibold leading-4"
-                :style="getTagStyle(getParentTag(transaction.tagDTO).colorDTO)"
-              >{{ getParentTag(transaction.tagDTO).label }}</span>
-            </div>
-
-            <!-- Amount + actions -->
-            <div class="shrink-0 flex flex-col items-end gap-0.5 py-0.5">
-              <span
-                class="text-xs font-extrabold tabular-nums leading-4"
-                :class="transaction.isIncome ? 'text-[#009CFE]' : 'text-[#FF084B]'"
-              >
-                {{ transaction.isIncome ? '+' : '-' }}{{ Number.parseFloat(transaction?.value?.toString() ?? '0').toFixed(2) }}€
+        <!-- Banking-style grouped by day -->
+        <template v-else>
+          <template v-for="group in transactionsByDay" :key="group.dateKey">
+            <!-- Day header -->
+            <div class="px-1 pt-4 pb-1.5 first:pt-1">
+              <span class="text-xs font-semibold text-[var(--text-tertiary)] tracking-wide">
+                {{ group.label }}
               </span>
-              <div class="flex items-center gap-0.5">
-                <button
-                  v-if="transaction.id"
-                  class="w-5 h-5 flex items-center justify-center text-[#A30053] rounded hover:bg-[#A30053]/10 transition-colors disabled:opacity-40"
-                  :disabled="isAnyActionLoading"
-                  aria-label="Modifier"
-                  @click.stop="onEditTransaction({ data: transaction })"
-                >
-                  <i class="pi pi-pencil text-[0.55rem]" />
-                </button>
-                <button
-                  v-if="transaction.isPreview"
-                  class="w-5 h-5 flex items-center justify-center text-emerald-600 rounded hover:bg-emerald-600/10 transition-colors disabled:opacity-40"
-                  :disabled="isAnyActionLoading"
-                  aria-label="Valider"
-                  @click.stop="onConfirmPreview(transaction)"
-                >
-                  <i class="pi pi-check text-[0.55rem]" :class="isConfirmPreviewLoading ? 'pi-spin' : ''" />
-                </button>
-              </div>
             </div>
-          </div>
-        </div>
+
+            <!-- Transactions card for this day -->
+            <div class="bg-[var(--card-bg)] rounded-xl overflow-hidden border border-[var(--card-border)] shadow-sm">
+              <template
+                v-for="(transaction, tIndex) in group.transactions"
+                :key="transaction.selectionKey || transaction.id || `t-${tIndex}`"
+              >
+                <div v-if="tIndex > 0" class="h-px mx-3" style="background: rgba(255,255,255,0.25)" />
+              <div
+                class="flex items-center gap-3 py-3 px-3 transition-colors active:bg-[var(--card-hover-bg)]"
+                :class="isSelected(transaction) ? 'bg-[var(--primary)]/5' : transaction.isPreview ? 'bg-amber-500/5' : ''"
+                @click="toggleSelection(transaction)"
+              >
+                <!-- Checkbox -->
+                <Checkbox
+                  :model-value="isSelected(transaction)"
+                  :binary="true"
+                  class="shrink-0"
+                  @click.stop="toggleSelection(transaction)"
+                />
+
+                <!-- Label + tag -->
+                <div class="flex-1 min-w-0">
+                  <div class="flex items-center gap-1.5">
+                    <span class="text-sm font-semibold text-[var(--text-primary)] truncate">{{ transaction.label }}</span>
+                    <i v-if="transaction.isPreview" class="pi pi-clock text-amber-500 text-xs shrink-0" />
+                  </div>
+                  <div class="mt-0.5">
+                    <span
+                      class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-semibold"
+                      :style="getTagStyle(getParentTag(transaction.tagDTO).colorDTO)"
+                    >{{ getParentTag(transaction.tagDTO).label }}</span>
+                  </div>
+                </div>
+
+                <!-- Amount + actions -->
+                <div class="shrink-0 flex flex-col items-end gap-1.5">
+                  <span
+                    class="text-base font-semibold tabular-nums"
+                    :class="transaction.isIncome ? 'text-[#009CFE]' : 'text-[#FF084B]'"
+                  >
+                    {{ transaction.isIncome ? '+' : '-' }}{{ Number.parseFloat(transaction?.value?.toString() ?? '0').toFixed(2) }}&nbsp;€
+                  </span>
+                  <div class="flex items-center gap-1">
+                    <button
+                      v-if="transaction.id"
+                      class="w-8 h-8 flex items-center justify-center text-[#A30053] rounded-lg hover:bg-[#A30053]/10 transition-colors disabled:opacity-40"
+                      :disabled="isAnyActionLoading"
+                      aria-label="Modifier"
+                      @click.stop="onEditTransaction({ data: transaction })"
+                    >
+                      <i class="pi pi-pencil text-xs" />
+                    </button>
+                    <button
+                      v-if="transaction.isPreview"
+                      class="w-8 h-8 flex items-center justify-center text-emerald-600 rounded-lg hover:bg-emerald-600/10 transition-colors disabled:opacity-40"
+                      :disabled="isAnyActionLoading"
+                      aria-label="Valider"
+                      @click.stop="onConfirmPreview(transaction)"
+                    >
+                      <i class="pi pi-check text-xs" :class="isConfirmPreviewLoading ? 'pi-spin' : ''" />
+                    </button>
+                  </div>
+                </div>
+              </div>
+              </template>
+            </div>
+          </template>
+        </template>
       </div>
 
       <TransactionCreationDialog


### PR DESCRIPTION
- BookletPageHeader: compact single-row layout on mobile (title + inline balances + stacked month/year pickers), replaces the oversized 3-row card
- BookletFilterActionBar: larger filter chips (px-3 py-1.5) with readable icons and touch-friendly sizing on mobile
- Booklet [id] page: banking-style grouped transaction list on mobile — transactions grouped by day with "Aujourd'hui" / "Hier" / "5 juin" headers, simplified rows (no day badge, label + tag + amount), amount displayed as text-base font-semibold, visible separator between rows (rgba(255,255,255,0.25))